### PR TITLE
History fix

### DIFF
--- a/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
+++ b/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
@@ -718,7 +718,11 @@ export class NgWhiteboardComponent implements OnInit, OnChanges, AfterViewInit, 
     }
     const currentState = this.undoStack.pop();
     this.redoStack.push(currentState as WhiteboardElement[]);
-    this.data = this.undoStack[this.undoStack.length - 1] || JSON.parse(JSON.stringify(this._initialData));
+    if(this.undoStack.length){
+      this.data = JSON.parse(JSON.stringify(this.undoStack[this.undoStack.length-1]));
+    } else {
+      this.data = JSON.parse(JSON.stringify(this._initialData)) || [];
+    }
     this.undo.emit();
   }
   private redoDraw() {

--- a/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
+++ b/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
@@ -77,6 +77,7 @@ export class NgWhiteboardComponent implements OnInit, OnChanges, AfterViewInit, 
 
   private _subscriptionList: Subscription[] = [];
 
+  private _initialData: WhiteboardElement[] = [];
   private undoStack: WhiteboardElement[][] = [];
   private redoStack: WhiteboardElement[][] = [];
   private _selectedTool: ToolsEnum = ToolsEnum.BRUSH;
@@ -101,6 +102,7 @@ export class NgWhiteboardComponent implements OnInit, OnChanges, AfterViewInit, 
   ngOnInit(): void {
     this._initInputsFromOptions(this.options);
     this._initObservables();
+    this._initialData = JSON.parse(JSON.stringify(this.data));
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -716,7 +718,7 @@ export class NgWhiteboardComponent implements OnInit, OnChanges, AfterViewInit, 
     }
     const currentState = this.undoStack.pop();
     this.redoStack.push(currentState as WhiteboardElement[]);
-    this.data = this.undoStack[this.undoStack.length - 1] || [];
+    this.data = this.undoStack[this.undoStack.length - 1] || JSON.parse(JSON.stringify(this._initialData));
     this.undo.emit();
   }
   private redoDraw() {


### PR DESCRIPTION
Fixed 2 issues with "undo" functionality.

In the basic example:
 	**action:** 				Draw a single line, than click the “undo” button
	**expected behaviour:**	The line is removed, the initial drawing (trough [data] input) remains
	**observed behaviour:** 	Both the line and the initial drawing are removed

In the basic example:
 	**action:** 				Draw two lines, than click the “undo” button, draw another line, click undo button
	**expected behaviour:**	Last line that was added is removed
	**observed behaviour:** 	Nothing happens. Clicking undo again removes all content