### PR TITLE
fix issue with undo/redo stacks

### DIFF
--- a/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
+++ b/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
@@ -730,7 +730,7 @@ export class NgWhiteboardComponent implements OnInit, OnChanges, AfterViewInit, 
       return;
     }
     const currentState = this.redoStack.pop();
-    this.undoStack.push(currentState as WhiteboardElement[]);
+    this.undoStack.push(JSON.parse(JSON.stringify(currentState)) as WhiteboardElement[]);
     this.data = currentState || [];
     this.redo.emit();
   }


### PR DESCRIPTION
Fixes an issue that can be reproduced doing the following:

draw, draw, undo, redo, draw, undo

Expected behaviour: last line drawn is removed
Observed behaviour: Nothing happens

Clicking again will result in last 2 lines being removed