### PR TITLE
🆕 feat(models): add ToolHandlers model to handle whiteboard tool events

### DIFF
--- a/projects/ng-whiteboard/src/lib/models/index.ts
+++ b/projects/ng-whiteboard/src/lib/models/index.ts
@@ -6,3 +6,4 @@ export * from './tools.enum';
 export * from './whiteboard-element.model';
 export * from './whiteboard-options.model';
 export * from './format.model';
+export * from './tool-handlers.model';

--- a/projects/ng-whiteboard/src/lib/models/tool-handlers.model.ts
+++ b/projects/ng-whiteboard/src/lib/models/tool-handlers.model.ts
@@ -1,0 +1,3 @@
+export interface ToolHandlers {
+  [key: string]: () => void;
+}

--- a/projects/ng-whiteboard/src/lib/ng-whiteboard.component.spec.ts
+++ b/projects/ng-whiteboard/src/lib/ng-whiteboard.component.spec.ts
@@ -71,6 +71,23 @@ describe('NgWhiteboardComponent', () => {
       expect(component.handleStartEvent).toHaveBeenCalled();
       expect(component['redoStack'].length).toBe(0);
     });
+    it('should return if drawingEnabled is false', () => {
+      // arrange
+      jest.spyOn(component, 'handleStartEvent');
+      const element = document.createElement('svg');
+      document.body.appendChild(element);
+      component.drawingEnabled = false;
+      const selection = select<Element, unknown>(element);
+      // act
+      component.initializeEvents.call(component, selection);
+      element.dispatchEvent(
+        new MouseEvent('mousedown', {
+          view: window,
+        })
+      );
+      // assert
+      expect(component.handleStartEvent).not.toHaveBeenCalled();
+    });
 
     it('should trigger drag event', () => {
       // arrange
@@ -223,6 +240,75 @@ describe('NgWhiteboardComponent', () => {
     });
   });
 
+  describe('handleStartEvent', () => {
+    it('should call the correct handler based on the selected tool', () => {
+      // arrange
+      component.selectedTool = ToolsEnum.BRUSH;
+      component.handleStartBrush = jest.fn();
+      component.handleImageTool = jest.fn();
+      component.handleStartLine = jest.fn();
+      component.handleStartRect = jest.fn();
+      component.handleStartEllipse = jest.fn();
+      component.handleTextTool = jest.fn();
+      component.handleSelectTool = jest.fn();
+      component.handleEraserTool = jest.fn();
+
+      // act
+      component.handleStartEvent();
+
+      // assert
+      expect(component.handleStartBrush).toHaveBeenCalled();
+      expect(component.handleImageTool).not.toHaveBeenCalled();
+      expect(component.handleStartLine).not.toHaveBeenCalled();
+      expect(component.handleStartRect).not.toHaveBeenCalled();
+      expect(component.handleStartEllipse).not.toHaveBeenCalled();
+      expect(component.handleTextTool).not.toHaveBeenCalled();
+      expect(component.handleSelectTool).not.toHaveBeenCalled();
+      expect(component.handleEraserTool).not.toHaveBeenCalled();
+    });
+  });
+  describe('handleDragEvent', () => {
+    it('should call the correct handler based on the selected tool', () => {
+      // arrange
+      component.selectedTool = ToolsEnum.BRUSH;
+      component.handleDragBrush = jest.fn();
+      component.handleDragLine = jest.fn();
+      component.handleDragRect = jest.fn();
+      component.handleDragEllipse = jest.fn();
+      component.handleTextDrag = jest.fn();
+
+      // act
+      component.handleDragEvent();
+
+      // assert
+      expect(component.handleDragBrush).toHaveBeenCalled();
+      expect(component.handleDragLine).not.toHaveBeenCalled();
+      expect(component.handleDragRect).not.toHaveBeenCalled();
+      expect(component.handleDragEllipse).not.toHaveBeenCalled();
+      expect(component.handleTextDrag).not.toHaveBeenCalled();
+    });
+  });
+  describe('handleEndEvent', () => {
+    it('should call the correct handler based on the selected tool', () => {
+      // arrange
+      component.selectedTool = ToolsEnum.BRUSH;
+      component.handleEndBrush = jest.fn();
+      component.handleEndLine = jest.fn();
+      component.handleEndRect = jest.fn();
+      component.handleEndEllipse = jest.fn();
+      component.handleTextEnd = jest.fn();
+
+      // act
+      component.handleEndEvent();
+
+      // assert
+      expect(component.handleEndBrush).toHaveBeenCalled();
+      expect(component.handleEndLine).not.toHaveBeenCalled();
+      expect(component.handleEndRect).not.toHaveBeenCalled();
+      expect(component.handleEndEllipse).not.toHaveBeenCalled();
+      expect(component.handleTextEnd).not.toHaveBeenCalled();
+    });
+  });
   describe('handleImageTool', () => {
     it('should add image to component when file is uploaded', () => {
       // Arrange

--- a/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
+++ b/projects/ng-whiteboard/src/lib/ng-whiteboard.component.ts
@@ -1,7 +1,31 @@
-import { Component, AfterViewInit, ViewChild, Input, ElementRef, OnDestroy, Output, EventEmitter, OnChanges, OnInit, SimpleChanges, ChangeDetectorRef } from '@angular/core';
+import {
+  Component,
+  AfterViewInit,
+  ViewChild,
+  Input,
+  ElementRef,
+  OnDestroy,
+  Output,
+  EventEmitter,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  ChangeDetectorRef,
+} from '@angular/core';
 import { NgWhiteboardService } from './ng-whiteboard.service';
 import { Subscription, fromEvent, skip, BehaviorSubject } from 'rxjs';
-import { ElementTypeEnum, FormatType, formatTypes, IAddImage, LineCapEnum, LineJoinEnum, ToolsEnum, WhiteboardElement, WhiteboardOptions } from './models';
+import {
+  ElementTypeEnum,
+  FormatType,
+  formatTypes,
+  IAddImage,
+  LineCapEnum,
+  LineJoinEnum,
+  ToolHandlers,
+  ToolsEnum,
+  WhiteboardElement,
+  WhiteboardOptions,
+} from './models';
 import { ContainerElement, curveBasis, drag, line, mouse, select, Selection, event } from 'd3';
 import Utils from './ng-whiteboard.utils';
 
@@ -245,75 +269,45 @@ export class NgWhiteboardComponent implements OnInit, OnChanges, AfterViewInit, 
   }
 
   handleStartEvent() {
-    switch (this.selectedTool) {
-      case ToolsEnum.BRUSH:
-        this.handleStartBrush();
-        break;
-      case ToolsEnum.IMAGE:
-        this.handleImageTool();
-        break;
-      case ToolsEnum.LINE:
-        this.handleStartLine();
-        break;
-      case ToolsEnum.RECT:
-        this.handleStartRect();
-        break;
-      case ToolsEnum.ELLIPSE:
-        this.handleStartEllipse();
-        break;
-      case ToolsEnum.TEXT:
-        this.handleTextTool();
-        break;
-      case ToolsEnum.SELECT:
-        this.handleSelectTool();
-        break;
-      case ToolsEnum.ERASER:
-        this.handleEraserTool();
-        break;
-      default:
-        break;
+    const toolHandlers: ToolHandlers = {
+      [ToolsEnum.BRUSH]: this.handleStartBrush,
+      [ToolsEnum.IMAGE]: this.handleImageTool,
+      [ToolsEnum.LINE]: this.handleStartLine,
+      [ToolsEnum.RECT]: this.handleStartRect,
+      [ToolsEnum.ELLIPSE]: this.handleStartEllipse,
+      [ToolsEnum.TEXT]: this.handleTextTool,
+      [ToolsEnum.SELECT]: this.handleSelectTool,
+      [ToolsEnum.ERASER]: this.handleEraserTool,
+    };
+    const handler = toolHandlers[this.selectedTool];
+    if (handler) {
+      handler.apply(this);
     }
   }
   handleDragEvent() {
-    switch (this.selectedTool) {
-      case ToolsEnum.BRUSH:
-        this.handleDragBrush();
-        break;
-      case ToolsEnum.LINE:
-        this.handleDragLine();
-        break;
-      case ToolsEnum.RECT:
-        this.handleDragRect();
-        break;
-      case ToolsEnum.ELLIPSE:
-        this.handleDragEllipse();
-        break;
-      case ToolsEnum.TEXT:
-        this.handleTextDrag();
-        break;
-      default:
-        break;
+    const toolHandlers: ToolHandlers = {
+      [ToolsEnum.BRUSH]: this.handleDragBrush,
+      [ToolsEnum.LINE]: this.handleDragLine,
+      [ToolsEnum.RECT]: this.handleDragRect,
+      [ToolsEnum.ELLIPSE]: this.handleDragEllipse,
+      [ToolsEnum.TEXT]: this.handleTextDrag,
+    };
+    const handler = toolHandlers[this.selectedTool];
+    if (handler) {
+      handler.apply(this);
     }
   }
   handleEndEvent() {
-    switch (this.selectedTool) {
-      case ToolsEnum.BRUSH:
-        this.handleEndBrush();
-        break;
-      case ToolsEnum.LINE:
-        this.handleEndLine();
-        break;
-      case ToolsEnum.RECT:
-        this.handleEndRect();
-        break;
-      case ToolsEnum.ELLIPSE:
-        this.handleEndEllipse();
-        break;
-      case ToolsEnum.TEXT:
-        this.handleTextEnd();
-        break;
-      default:
-        break;
+    const toolHandlers: ToolHandlers = {
+      [ToolsEnum.BRUSH]: this.handleEndBrush,
+      [ToolsEnum.LINE]: this.handleEndLine,
+      [ToolsEnum.RECT]: this.handleEndRect,
+      [ToolsEnum.ELLIPSE]: this.handleEndEllipse,
+      [ToolsEnum.TEXT]: this.handleTextEnd,
+    };
+    const handler = toolHandlers[this.selectedTool];
+    if (handler) {
+      handler.apply(this);
     }
   }
   // Handle Brush tool


### PR DESCRIPTION
🔬 test(ng-whiteboard.component.spec.ts): add test to check if handleStartEvent is not called when drawingEnabled is false

🔬 test(ng-whiteboard.component.spec.ts): add tests for handleStartEvent, handleDragEvent, and handleEndEvent methods

🎨 style(ng-whiteboard.component.ts): format imports and add missing imports
🔨 refactor(ng-whiteboard.component.ts): rename ToolHandlers interface to ToolHandlersMap
🚀 perf(ng-whiteboard.component.ts): optimize imports and remove unused imports

🔧 refactor(ng-whiteboard.component.ts): use object literal to map tool handlers in handleStartEvent, handleDragEvent, and handleEndEvent methods