### PR TITLE
Fix: Prevent Spacebar shortcut from interfering with text input

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
@@ -90,9 +90,7 @@ export class SvgService {
     this.pointerUpSig.set(info);
   }
 
-  onKeyDown(event: KeyboardEvent) {
-    
-    // ---------------- [Begin of fix code] ----------------
+  onKeyDown(event: KeyboardEvent) {    
     // Check whether the target is an input box, textarea, or an editable element
     const target = event.target as HTMLElement;
     if(target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)){


### PR DESCRIPTION
## Description

This Pull Request resolves a bug where the global Spacebar shortcut for temporary canvas panning conflicts with the Text tool functionality.

### 🐛 Bug Description

When a user selects the Text tool and is actively inputting text (e.g., using a textarea), holding the Spacebar incorrectly triggers the temporary Hand tool for panning. This behavior intercepts the keypress event, preventing the user from successfully inserting space characters into their text content.

### ✨ Solution

A minimal, targeted fix is implemented by adding a guard clause to the primary keyboard event handler (`onKeyDown` method).

The handler now includes a check to verify if the event target is an element commonly used for text input:

1.  It determines if `event.target` is an `<input>`, `<textarea>`, or a `[contenteditable]` element.
2.  If the user is typing, the function immediately returns (`return;`), allowing the browser's default behavior (inserting a space) to proceed without triggering the panning shortcut.

This ensures the spacebar shortcut only activates when the user is focused on the canvas and not on a text input field.