### PR TITLE
fix: Handle Unicode characters in save function

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
@@ -90,7 +90,8 @@ export class SvgService {
     this.pointerUpSig.set(info);
   }
 
-  onKeyDown(event: KeyboardEvent) {    
+  onKeyDown(event: KeyboardEvent) {
+    
     // Check whether the target is an input box, textarea, or an editable element
     const target = event.target as HTMLElement;
     if(target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)){

--- a/projects/ng-whiteboard/src/lib/core/utils/svg/svg.ts
+++ b/projects/ng-whiteboard/src/lib/core/utils/svg/svg.ts
@@ -31,7 +31,10 @@ export function svgToBase64(
     const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
 
     const img = new Image();
-    img.src = `data:image/svg+xml;base64,${btoa(svgString)}`;
+    
+    const encodedSvg = encodeURIComponent(svgString);
+    img.src = `data:image/svg+xml;charset=utf-8,${encodedSvg}`;
+
     img.onload = () => {
       ctx.drawImage(img, 0, 0, width, height);
       const base64 = canvas.toDataURL(`image/${format}`);


### PR DESCRIPTION
## Description
Fixes an issue where saving the whiteboard fails when text elements contain Unicode characters (e.g. emoji).

## Problem
The `btoa()` function only supports Latin1 (ISO-8859-1) character set and throws `InvalidCharacterError` when encountering Unicode characters.

## Solution
Replaced `btoa()` with `encodeURIComponent()` to properly encode Unicode characters in SVG strings before creating data URLs.

## Changes
- Modified `svgToBase64()` function in `svg.utils.ts`
- Changed from `btoa(svgString)` to `encodeURIComponent(svgString)`
