### PR TITLE
fix(select-tool): commit transform gestures as a single history entry

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/api/api.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/api/api.service.ts
@@ -7,7 +7,7 @@ import { LayerManagementService } from '../elements/layer-management.service';
 import { PanService } from '../viewport/pan.service';
 import { SelectionService } from '../elements/selection.service';
 import { ToolsService } from '../tools/tools.service';
-import { HistoryService } from '../history/history.service';
+import { BatchHandle, HistoryService } from '../history/history.service';
 import { ZoomService } from '../viewport/zoom.service';
 import {
   AddImage,
@@ -433,6 +433,24 @@ export class ApiService {
 
   recordElementCreation(before: WhiteboardElement[], after: WhiteboardElement[]): void {
     this.historyService.recordElementCreation(before, after);
+  }
+
+  /**
+   * Begin a history batch: while active, element-change recordings are coalesced
+   * so a multi-step gesture (e.g. a drag, resize or rotate spanning many frames)
+   * is committed as a single undo entry. Pair every call with the returned
+   * handle's execute()/clear().
+   */
+  startBatch(description: string, before: WhiteboardElement[]): BatchHandle {
+    return this.historyService.startBatch(description, before);
+  }
+
+  /**
+   * Record the final state of an in-progress history batch. Call before the
+   * handle's execute().
+   */
+  completeBatch(after: WhiteboardElement[]): void {
+    this.historyService.completeBatch(after);
   }
 
   recordElementUpdate(before: WhiteboardElement[], after: WhiteboardElement[]): void {

--- a/projects/ng-whiteboard/src/lib/core/history/history.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/history/history.service.ts
@@ -8,7 +8,7 @@ interface HistoryEntry {
   timestamp: number;
 }
 
-interface BatchHandle {
+export interface BatchHandle {
   execute: () => void;
   clear: () => void;
 }

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/select-tool.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/select-tool.test.ts
@@ -106,6 +106,8 @@ describe('SelectTool', () => {
       resetCursor: jest.fn(),
       updateElements: jest.fn(),
       setBoundingBox: jest.fn(),
+      startBatch: jest.fn().mockReturnValue({ execute: jest.fn(), clear: jest.fn() }),
+      completeBatch: jest.fn(),
     } as unknown as ApiService;
 
     selectTool = new SelectTool(apiService);
@@ -125,6 +127,66 @@ describe('SelectTool', () => {
     it('should clear selection on deactivate', () => {
       selectTool.onDeactivate();
       expect(apiService.clearSelection).toHaveBeenCalled();
+    });
+  });
+
+  describe('history batching (transform gestures)', () => {
+    it('collapses a multi-frame move gesture into a single history batch', () => {
+      const execute = jest.fn();
+      const clear = jest.fn();
+      (apiService.startBatch as jest.Mock).mockReturnValue({ execute, clear });
+
+      selectTool['currentAction'] = SelectAction.Move;
+      selectTool['startPoint'] = { x: 50, y: 100 };
+      jest.spyOn(selectTool, 'getPointerPosition').mockReturnValue({ x: 100, y: 200 });
+
+      // Several move frames in the same gesture...
+      selectTool.handlePointerMove(createMockPointerInfo({ x: 150, y: 300, eventType: 'pointermove' }));
+      flushRAF();
+      selectTool.handlePointerMove(createMockPointerInfo({ x: 160, y: 320, eventType: 'pointermove' }));
+      flushRAF();
+
+      // ...open exactly one batch, not one per frame, and don't commit yet.
+      expect(apiService.startBatch).toHaveBeenCalledTimes(1);
+      expect(apiService.startBatch).toHaveBeenCalledWith('Move element', expect.anything());
+      expect(execute).not.toHaveBeenCalled();
+
+      selectTool.handlePointerUp();
+
+      // pointer up commits the batch as a single undo entry.
+      expect(apiService.completeBatch).toHaveBeenCalledTimes(1);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(clear).not.toHaveBeenCalled();
+    });
+
+    it('does not open a batch for a click without movement', () => {
+      const target = { id: ITEM_PREFIX + '1', getAttribute: jest.fn().mockReturnValue('1') };
+      (getMouseTarget as jest.Mock).mockReturnValue(target);
+      apiService.getElements = jest.fn().mockReturnValue([{ id: '1' }]);
+
+      selectTool.handlePointerDown(createMockPointerInfo({ x: 10, y: 10, eventType: 'pointerdown' }));
+      selectTool.handlePointerUp();
+
+      expect(apiService.startBatch).not.toHaveBeenCalled();
+      expect(apiService.completeBatch).not.toHaveBeenCalled();
+    });
+
+    it('clears an open batch if the gesture is interrupted by deactivation', () => {
+      const execute = jest.fn();
+      const clear = jest.fn();
+      (apiService.startBatch as jest.Mock).mockReturnValue({ execute, clear });
+
+      selectTool['currentAction'] = SelectAction.Move;
+      selectTool['startPoint'] = { x: 0, y: 0 };
+      jest.spyOn(selectTool, 'getPointerPosition').mockReturnValue({ x: 5, y: 5 });
+      selectTool.handlePointerMove(createMockPointerInfo({ x: 5, y: 5, eventType: 'pointermove' }));
+      flushRAF();
+      expect(apiService.startBatch).toHaveBeenCalledTimes(1);
+
+      selectTool.onDeactivate();
+
+      expect(clear).toHaveBeenCalledTimes(1);
+      expect(execute).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/ng-whiteboard/src/lib/core/tools/select-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/select-tool.ts
@@ -18,6 +18,7 @@ import { getElementBounds } from '../utils/dom/element';
 
 import { BaseTool } from './base-tool';
 import { CursorType } from '../types/cursors';
+import { BatchHandle } from '../history/history.service';
 
 export enum SelectAction {
   None,
@@ -58,6 +59,18 @@ export class SelectTool extends BaseTool {
   // Track whether arrow bindings were detached during current move
   private arrowBindingsDetached = false;
 
+  // Actions that transform existing elements over many frames; each must collapse
+  // into a single undo entry via a history batch (see handlePointerMove/Up).
+  private static readonly TRANSFORM_ACTIONS: ReadonlySet<SelectAction> = new Set([
+    SelectAction.Move,
+    SelectAction.Resize,
+    SelectAction.Rotate,
+    SelectAction.DragEndpoint,
+    SelectAction.DragCurveHandle,
+  ]);
+  // Open history batch for the in-progress transform gesture, if any.
+  private transformBatch: BatchHandle | null = null;
+
   // Injected connection services
   private connectionPointsService!: ConnectionPointsService;
   private arrowBindingService!: ArrowBindingService;
@@ -82,7 +95,30 @@ export class SelectTool extends BaseTool {
   }
 
   override onDeactivate(): void {
+    // Drop any batch left open by a gesture interrupted mid-flight, so the
+    // history service never stays stuck in batching mode.
+    if (this.transformBatch) {
+      this.transformBatch.clear();
+      this.transformBatch = null;
+    }
     this.apiService.clearSelection();
+  }
+
+  private batchDescriptionFor(action: SelectAction): string {
+    switch (action) {
+      case SelectAction.Move:
+        return 'Move element';
+      case SelectAction.Resize:
+        return 'Resize element';
+      case SelectAction.Rotate:
+        return 'Rotate element';
+      case SelectAction.DragEndpoint:
+        return 'Move endpoint';
+      case SelectAction.DragCurveHandle:
+        return 'Adjust curve';
+      default:
+        return 'Transform element';
+    }
   }
 
   override handlePointerDown(event: PointerInfo): void {
@@ -142,6 +178,17 @@ export class SelectTool extends BaseTool {
 
         const event = this.pendingPointerEvent;
         const currentPoint = this.getPointerPosition(event);
+
+        // Open a history batch on the first transform frame: from here every
+        // per-frame element update is coalesced, so the whole gesture commits as
+        // one undo entry on pointer up. A plain click never reaches here, so no
+        // batch is left dangling.
+        if (!this.transformBatch && SelectTool.TRANSFORM_ACTIONS.has(this.currentAction)) {
+          this.transformBatch = this.apiService.startBatch(
+            this.batchDescriptionFor(this.currentAction),
+            this.apiService.getElements()
+          );
+        }
 
         switch (this.currentAction) {
           case SelectAction.Move:
@@ -206,6 +253,13 @@ export class SelectTool extends BaseTool {
       if (arrowUpdates.length > 0) {
         this.apiService.updateElements(arrowUpdates as Array<Partial<WhiteboardElement> & { id: string }>);
       }
+    }
+
+    // Commit the gesture's coalesced changes as a single undo entry.
+    if (this.transformBatch) {
+      this.apiService.completeBatch(this.apiService.getElements());
+      this.transformBatch.execute();
+      this.transformBatch = null;
     }
 
     this.initialElementStates.clear();


### PR DESCRIPTION
  ## Problem
  Moving, resizing or rotating a selection records one history entry **per
  animation frame** (`updateElements()` → `recordElementUpdate()` runs every
  rAF tick during the drag). A single drag therefore floods the 50-entry undo
  stack: one Undo only nudges the gesture back a single frame, and a long
  gesture evicts all older history entries.

  ## Fix
  `HistoryService` already exposes a batch API (`startBatch`/`completeBatch`
  + `BatchHandle`) that suppresses per-change recording and commits one
  before/after entry — but nothing used it. This wires the SelectTool
  transform gestures (move/resize/rotate/endpoint/curve) through it:
  - open a batch on the first transform frame,
  - let the per-frame updates coalesce (no source changes to the move handlers),
  - commit a single entry on pointer up,
  - clear the batch on deactivation so an interrupted gesture can't leave the
    history service stuck in batching mode.

  Net: one gesture = one undo entry. Also improves UX generally (a single Undo
  4. Corpo PR (pronto da incollare):
  ## Problem
  Moving, resizing or rotating a selection records one history entry **per
  animation frame** (`updateElements()` → `recordElementUpdate()` runs every
  rAF tick during the drag). A single drag therefore floods the 50-entry undo
  stack: one Undo only nudges the gesture back a single frame, and a long
  gesture evicts all older history entries.

  ## Fix
  `HistoryService` already exposes a batch API (`startBatch`/`completeBatch`
  + `BatchHandle`) that suppresses per-change recording and commits one
  before/after entry — but nothing used it. This wires the SelectTool
  transform gestures (move/resize/rotate/endpoint/curve) through it:
  - open a batch on the first transform frame,
  - let the per-frame updates coalesce (no source changes to the move handlers),
  - commit a single entry on pointer up,
  - clear the batch on deactivation so an interrupted gesture can't leave the
    history service stuck in batching mode.

  Net: one gesture = one undo entry. Also improves UX generally (a single Undo
  now reverts the whole movement).

  ## Notes
  - Non-breaking. Adds `ApiService.startBatch/completeBatch` and exports the
    existing `BatchHandle` interface.
  - Pen drawing already used the draft lifecycle, so it was unaffected.

  ## Tests
  Added `SelectTool` specs: a multi-frame move opens exactly one batch and
  commits once on pointer up; a click without movement opens none; an
  interrupted gesture clears the batch.