### PR TITLE
ci: pin format:check base to origin/master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Format check
-        run: yarn format:check
+        run: npx nx format:check --base=origin/master
 
       - name: Lint
         run: npx nx run-many -t lint


### PR DESCRIPTION
Follow-up to #350. The `Format check` step failed in CI because `nx format:check` diffs against a local `master` branch that doesn't exist on the runner, falling back to checking all files. Pin the base to `origin/master`.

Verified locally: `npx nx format:check --base=origin/master` exits 0.