### PR TITLE
fix(export): keep rotated elements in place when exporting (#339)

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/input/io.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/input/io.service.spec.ts
@@ -683,6 +683,14 @@ describe('IOService', () => {
       expect(mockSvgElement.getAttribute('x')).toBe('100');
       expect(mockSvgElement.getAttribute('y')).toBe('50');
     });
+
+    it('should embed transform-origin styles so rotated elements export at the correct position', async () => {
+      await service.save(FormatType.Png);
+
+      const svgString = mockSvgToBase64.mock.calls[0][0];
+      expect(svgString).toContain('transform-box: fill-box');
+      expect(svgString).toContain('transform-origin: center');
+    });
   });
 
   describe('Export convenience methods', () => {

--- a/projects/ng-whiteboard/src/lib/core/input/io.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/input/io.service.ts
@@ -431,6 +431,15 @@ export class IOService {
   private prepareSvgForExport(svgElement: SVGSVGElement): SVGSVGElement {
     const svgClone = svgElement.cloneNode(true) as SVGSVGElement;
 
+    // Elements render with `transform-box: fill-box; transform-origin: center`
+    // via the component stylesheet, so rotation and scale pivot around each
+    // element's geometry center. That stylesheet is not part of the serialized
+    // SVG, so without these rules the export pivots around the local origin and
+    // rotated/scaled elements drift. Inline the rules to match the live render.
+    const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+    style.textContent = '.wb_element { transform-box: fill-box; transform-origin: center; }';
+    svgClone.insertBefore(style, svgClone.firstChild);
+
     const selectorParentGroup = svgClone.querySelector('#selectorParentGroup');
     if (selectorParentGroup) {
       selectorParentGroup.remove();


### PR DESCRIPTION
## Summary

Fixes #339 — rotated (and scaled) elements rendered in the wrong position when exporting to PNG/JPEG/Base64.

## Root cause

Elements render with `transform-box: fill-box; transform-origin: center` from the canvas component stylesheet, so rotation and scale pivot around each element's geometry center (the same model the #338 bounding-box fix aligned to). The export path (`IOService.prepareSvgForExport`) only clones and serializes the SVG DOM — the component stylesheet is not part of the serialized SVG. When the string is rasterized via `<img>` → `<canvas>`, the missing rule makes `rotate()`/`scale()` pivot around the local origin `(0,0)`, displacing every rotated element.

## Fix

Inline the same CSS rule into the cloned SVG before serialization so the exported image matches the live render.

## Verification

Confirmed in a real browser through the exact `<img>` data-URI → `<canvas>` export path:

| | rect center | bbox |
|---|---|---|
| Expected (live render) | (200, 150) | x[150,250] y[50,250] |
| **With fix** | (199.5, 149.5) ✅ | x[150,250] y[50,250] ✅ |
| Without fix (the bug) | (49.5, 199.5) ❌ | x[0,99] y[100,299] |

- Added a regression test in `io.service.spec.ts` (red → green).
- Full library suite: 2388 passing, lint clean.
