### PR TITLE
fix(selection): align bounding box with rendered transform-origin (#338)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,92 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # npm / yarn dependencies
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    # Batch related packages so version bumps arrive as a handful of PRs
+    # instead of one per package.
+    groups:
+      angular:
+        patterns:
+          - "@angular*"
+          - "@schematics/angular"
+          - "ng-packagr"
+          - "zone.js"
+      nx:
+        patterns:
+          - "@nx/*"
+          - "nx"
+      eslint:
+        patterns:
+          - "*eslint*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+          - "angular-eslint"
+      testing:
+        patterns:
+          - "*jest*"
+          - "ts-jest"
+          - "cypress"
+          - "@types/*"
+      semantic-release:
+        patterns:
+          - "semantic-release"
+          - "@semantic-release/*"
+          - "@theunderscorer/nx-semantic-release"
+      # Sweep everything else into two type-based groups.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      # Collapse all groupable security fixes (incl. transitive deps) into a
+      # single PR rather than one run per advisory.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      # Project is intentionally pinned to the Angular 17 line; majors need a
+      # coordinated framework migration, not an automated bump.
+      - dependency-name: "@angular*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@schematics/angular"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ng-packagr"
+        update-types: ["version-update:semver-major"]
+      # Angular 17 supports TypeScript >=5.2 <5.5 — block incompatible bumps.
+      - dependency-name: "typescript"
+        versions: [">=5.5.0"]
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions used in workflows (also clears the Node 20 deprecation
+  # warning by bumping checkout/setup-node/codecov to current majors).
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/projects/ng-whiteboard/src/lib/core/elements/__tests__/text-element.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/__tests__/text-element.test.ts
@@ -44,8 +44,8 @@ describe('TextElementUtil', () => {
     const textElement = textElementUtil.create({ x: 0, y: 0, scaleX: 1, scaleY: 1 });
     const resizedElement = textElementUtil.resize(textElement, Direction.NW, 10, -10);
 
-    expect(resizedElement.x).toBe(10);
-    expect(resizedElement.y).toBe(-10);
+    expect(resizedElement.x).toBe(5);
+    expect(resizedElement.y).toBe(-5);
     expect(resizedElement.scaleX).toBeLessThan(1);
     expect(resizedElement.scaleY).toBeGreaterThan(1);
   });
@@ -54,7 +54,7 @@ describe('TextElementUtil', () => {
     const textElement = textElementUtil.create({ x: 0, y: 0, scaleX: 1, scaleY: 1 });
     const resizedElement = textElementUtil.resize(textElement, Direction.N, 0, 10);
 
-    expect(resizedElement.y).toBe(10);
+    expect(resizedElement.y).toBe(5);
     expect(resizedElement.scaleY).toBeLessThan(1);
   });
 
@@ -62,7 +62,7 @@ describe('TextElementUtil', () => {
     const textElement = textElementUtil.create({ x: 0, y: 0, scaleX: 1, scaleY: 1 });
     const resizedElement = textElementUtil.resize(textElement, Direction.NE, 10, 10);
 
-    expect(resizedElement.y).toBe(10);
+    expect(resizedElement.y).toBe(5);
     expect(resizedElement.scaleX).toBeGreaterThan(1);
     expect(resizedElement.scaleY).toBeLessThan(1);
   });
@@ -93,7 +93,7 @@ describe('TextElementUtil', () => {
     const textElement = textElementUtil.create({ x: 0, y: 0, scaleX: 1, scaleY: 1 });
     const resizedElement = textElementUtil.resize(textElement, Direction.SW, 10, 10);
 
-    expect(resizedElement.x).toBe(10);
+    expect(resizedElement.x).toBe(5);
     expect(resizedElement.scaleX).toBeLessThan(1);
     expect(resizedElement.scaleY).toBeGreaterThan(1);
   });
@@ -102,7 +102,7 @@ describe('TextElementUtil', () => {
     const textElement = textElementUtil.create({ x: 0, y: 0, scaleX: 1, scaleY: 1 });
     const resizedElement = textElementUtil.resize(textElement, Direction.W, 10, 0);
 
-    expect(resizedElement.x).toBe(10);
+    expect(resizedElement.x).toBe(5);
     expect(resizedElement.scaleX).toBeLessThan(1);
   });
 
@@ -383,6 +383,58 @@ describe('TextElementUtil', () => {
       // Bounds should be much larger with large scale
       expect(bounds.width).toBeGreaterThan(16 * 3 * 0.6 * 3); // Scaled up
       expect(bounds.height).toBeGreaterThan(16 * 1.2 * 3); // Scaled up
+    });
+  });
+
+  describe('scale-around-center (issue #338)', () => {
+    // The element <g> renders with CSS transform-box:fill-box; transform-origin:center,
+    // so scale pivots around the geometry's center, not the local origin. The bounding
+    // box must reflect that or it drifts away from the rendered text.
+
+    it('keeps the bounding-box center fixed when scaleX changes', () => {
+      const base = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 1, scaleY: 1, style: { fontSize: 16 } });
+      const scaled = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 3, scaleY: 1, style: { fontSize: 16 } });
+      const b1 = textElementUtil.getBounds(base);
+      const b2 = textElementUtil.getBounds(scaled);
+      expect(b2.minX + b2.width / 2).toBeCloseTo(b1.minX + b1.width / 2, 6);
+    });
+
+    it('keeps the bounding-box center fixed when scaleY changes', () => {
+      const base = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 1, scaleY: 1, style: { fontSize: 16 } });
+      const scaled = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 1, scaleY: 3, style: { fontSize: 16 } });
+      const b1 = textElementUtil.getBounds(base);
+      const b2 = textElementUtil.getBounds(scaled);
+      expect(b2.minY + b2.height / 2).toBeCloseTo(b1.minY + b1.height / 2, 6);
+    });
+
+    it('anchors the left edge and moves the right edge by the drag delta when resizing E', () => {
+      const el = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 1, scaleY: 1, style: { fontSize: 16 } });
+      const before = textElementUtil.getBounds(el);
+      const dx = 40;
+      const resized = textElementUtil.resize({ ...el }, Direction.E, dx, 0);
+      const after = textElementUtil.getBounds(resized);
+      expect(after.minX).toBeCloseTo(before.minX, 6);
+      expect(after.maxX).toBeCloseTo(before.maxX + dx, 6);
+    });
+
+    it('anchors the right edge and moves the left edge by the drag delta when resizing W', () => {
+      const el = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 1, scaleY: 1, style: { fontSize: 16 } });
+      const before = textElementUtil.getBounds(el);
+      const dx = -30;
+      const resized = textElementUtil.resize({ ...el }, Direction.W, dx, 0);
+      const after = textElementUtil.getBounds(resized);
+      expect(after.maxX).toBeCloseTo(before.maxX, 6);
+      expect(after.minX).toBeCloseTo(before.minX + dx, 6);
+    });
+
+    it('anchors the top edge and moves the bottom edge by the drag delta when resizing S', () => {
+      const el = textElementUtil.create({ x: 100, y: 50, text: 'Hello', scaleX: 1, scaleY: 1, style: { fontSize: 16 } });
+      const before = textElementUtil.getBounds(el);
+      const dy = 25;
+      const resized = textElementUtil.resize({ ...el }, Direction.S, 0, dy);
+      const after = textElementUtil.getBounds(resized);
+      expect(after.minY).toBeCloseTo(before.minY, 6);
+      expect(after.maxY).toBeCloseTo(before.maxY + dy, 6);
     });
   });
 

--- a/projects/ng-whiteboard/src/lib/core/elements/selection.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/selection.service.ts
@@ -3,7 +3,8 @@ import { EventBusService } from '../event-bus';
 import { CanvasService } from '../canvas/canvas.service';
 import { ClipboardService } from '../input/clipboard.service';
 import { ToolsService } from '../tools/tools.service';
-import { AlignmentType, BoundingBox, ElementType, SelectionBox, ToolType, WhiteboardElement } from '../types';
+import { AlignmentType, Bounds, BoundingBox, ElementType, SelectionBox, ToolType, WhiteboardElement } from '../types';
+import { TextElement } from './text-element';
 import { WhiteboardEvent } from '../types/events';
 import { getElementBounds } from '../utils/dom';
 import { getCombinedScreenBounds } from '../utils/geometry/transform-utils';
@@ -403,6 +404,75 @@ export class SelectionService {
     return expandedElements.map((el) => el.id);
   }
 
+  /**
+   * Measures text element bounds by creating a temporary hidden SVG <text> element
+   * with matching font properties and calling getBBox() synchronously.
+   * This avoids depending on Angular's rendering cycle — the element need not be in
+   * the live DOM yet.
+   */
+  private measureTextElementSvg(element: WhiteboardElement): Bounds | null {
+    try {
+      if (!this.canvasService.isCanvasInitialized()) return null;
+      const svgContainer = this.canvasService.getCanvas();
+
+      const textEl = element as TextElement;
+      const fontSize = textEl.style.fontSize ?? 16;
+      const fontFamily = textEl.style.fontFamily ?? 'Arial';
+      const fontStyle = textEl.style.fontStyle ?? 'normal';
+      const fontWeight = textEl.style.fontWeight ?? 'normal';
+      const lineHeight = fontSize * 1.2;
+      const lines = (textEl.text ?? '').split('\n');
+      const scaleX = element.scaleX ?? 1;
+      const scaleY = element.scaleY ?? 1;
+
+      // Create a hidden temporary <text> matching the template's font attributes
+      const tempText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      tempText.setAttribute('text-anchor', 'start');
+      tempText.setAttribute('alignment-baseline', 'before-edge');
+      tempText.setAttribute('font-size', String(fontSize));
+      tempText.setAttribute('font-family', fontFamily);
+      tempText.setAttribute('font-style', fontStyle);
+      tempText.setAttribute('font-weight', fontWeight);
+      tempText.style.visibility = 'hidden';
+
+      lines.forEach((line: string, i: number) => {
+        const tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
+        tspan.setAttribute('x', '0');
+        tspan.setAttribute('dy', i === 0 ? '0' : String(lineHeight));
+        // Use zero-width space for empty lines to preserve height contribution
+        tspan.textContent = line.length > 0 ? line : '\u200B';
+        tempText.appendChild(tspan);
+      });
+
+      svgContainer.appendChild(tempText);
+      const bbox = tempText.getBBox();
+      svgContainer.removeChild(tempText);
+
+      if (bbox.width === 0 && bbox.height === 0) return null;
+
+      // Scale is applied around the fill-box center (transform-box: fill-box;
+      // transform-origin: center), so position the scaled box about that center
+      // rather than the local origin — otherwise the box drifts from the rendered text.
+      const centerX = bbox.x + bbox.width / 2;
+      const centerY = bbox.y + bbox.height / 2;
+      const width = bbox.width * scaleX;
+      const height = bbox.height * scaleY;
+      const minX = element.x + centerX - width / 2;
+      const minY = element.y + centerY - height / 2;
+
+      return {
+        minX,
+        minY,
+        maxX: minX + width,
+        maxY: minY + height,
+        width,
+        height,
+      };
+    } catch {
+      return null;
+    }
+  }
+
   private calculateBoundingBox(elements: WhiteboardElement[]): BoundingBox {
     let bounds;
     let rotation = 0;
@@ -413,9 +483,12 @@ export class SelectionService {
       const element = elements[0];
       rotation = element.rotation || 0;
 
-      // Get bounds in local space (relative to element origin)
-      // For rectangles, this returns {minX: element.x, minY: element.y, width, height}
-      bounds = getElementBounds(element);
+      // For text elements, measure via a temporary SVG element for accurate font metrics
+      if (element.type === ElementType.Text) {
+        bounds = this.measureTextElementSvg(element) ?? getElementBounds(element);
+      } else {
+        bounds = getElementBounds(element);
+      }
     } else {
       // For multiple elements, use screen-space bounds that account for rotation
       const combinedBounds = getCombinedScreenBounds(elements);

--- a/projects/ng-whiteboard/src/lib/core/elements/text-element.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/text-element.ts
@@ -2,6 +2,100 @@ import { BaseElement, Bounds, Direction, ElementType, ElementUtil, Point, defaul
 import { generateId } from '../utils/common';
 import { hitTestBoundingBox } from '../utils/drawing';
 
+interface TextNaturalDimensions {
+  naturalWidth: number;
+  naturalHeight: number;
+  bboxX: number;
+  bboxY: number;
+}
+
+/**
+ * Measures the natural (pre-scale) dimensions of a text element by creating a
+ * temporary SVG in the document. Returns null if measurement fails or in SSR.
+ */
+function measureTextNatural(element: TextElement): TextNaturalDimensions | null {
+  try {
+    if (typeof document === 'undefined') return null;
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const fontSize = element.style.fontSize ?? 16;
+    const fontFamily = element.style.fontFamily ?? 'Arial';
+    const fontStyle = element.style.fontStyle ?? 'normal';
+    const fontWeight = String(element.style.fontWeight ?? 'normal');
+    const lineHeight = fontSize * 1.2;
+    const lines = (element.text ?? '').split('\n');
+
+    const tempSvg = document.createElementNS(svgNS, 'svg') as SVGSVGElement;
+    tempSvg.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none;width:0;height:0;overflow:hidden;';
+    document.body.appendChild(tempSvg);
+
+    const tempText = document.createElementNS(svgNS, 'text') as SVGTextElement;
+    tempText.setAttribute('text-anchor', 'start');
+    tempText.setAttribute('alignment-baseline', 'before-edge');
+    tempText.setAttribute('font-size', String(fontSize));
+    tempText.setAttribute('font-family', fontFamily);
+    tempText.setAttribute('font-style', fontStyle);
+    tempText.setAttribute('font-weight', fontWeight);
+
+    lines.forEach((line: string, i: number) => {
+      const tspan = document.createElementNS(svgNS, 'tspan') as SVGTSpanElement;
+      tspan.setAttribute('x', '0');
+      tspan.setAttribute('dy', i === 0 ? '0' : String(lineHeight));
+      tspan.textContent = line.length > 0 ? line : '\u200B';
+      tempText.appendChild(tspan);
+    });
+
+    tempSvg.appendChild(tempText);
+    const bbox = tempText.getBBox();
+    document.body.removeChild(tempSvg);
+
+    if (bbox.width === 0 && bbox.height === 0) return null;
+
+    return { naturalWidth: bbox.width, naturalHeight: bbox.height, bboxX: bbox.x, bboxY: bbox.y };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Natural (pre-scale) geometry of a text element, in the element's local coordinate
+ * space. `(ox, oy)` is the center of the text's fill-box — the pivot that the renderer
+ * scales and rotates around (CSS `transform-box: fill-box; transform-origin: center`).
+ */
+interface TextNaturalMetrics {
+  width: number;
+  height: number;
+  /** fill-box center, local space (unscaled) */
+  ox: number;
+  oy: number;
+}
+
+/**
+ * Resolves the natural (unscaled) text metrics, preferring real font measurement and
+ * falling back to font-size estimates when measurement is unavailable (e.g. SSR/tests).
+ * getBounds and resize share this so the displayed box and the resize math always agree.
+ */
+function getNaturalMetrics(element: TextElement): TextNaturalMetrics {
+  const fontSize = element.style.fontSize ?? defaultTextElementStyle.fontSize ?? 16;
+  const measured = measureTextNatural(element);
+
+  if (measured) {
+    return {
+      width: measured.naturalWidth,
+      height: measured.naturalHeight,
+      ox: measured.bboxX + measured.naturalWidth / 2,
+      oy: measured.bboxY + measured.naturalHeight / 2,
+    };
+  }
+
+  const lines = (element.text ?? '').split('\n');
+  const maxChars = lines.reduce((max, line) => Math.max(max, line.length), 0);
+  const width = fontSize * 0.6 * maxChars || fontSize;
+  const height = fontSize * 1.2 * lines.length || fontSize * 1.2;
+  // SVG text origin is at the first baseline; the visual top sits ~0.8*fontSize above it.
+  const bboxY = -(fontSize * 0.8);
+  return { width, height, ox: width / 2, oy: bboxY + height / 2 };
+}
+
 export interface TextElement extends BaseElement {
   type: ElementType.Text;
   text: string;
@@ -33,73 +127,46 @@ export class TextElementUtil implements ElementUtil<TextElement> {
 
   resize(element: TextElement, direction: Direction, dx: number, dy: number): TextElement {
     const MIN_SCALE = 0.1;
-    const SCALE_FACTOR = 0.016;
+    const { width, height } = getNaturalMetrics(element);
 
-    const scaleXChange = dx * SCALE_FACTOR;
-    const scaleYChange = dy * SCALE_FACTOR;
+    // Scale pivots around the fill-box center, so dragging an edge by `d` (in local
+    // space) changes the scale by `d / naturalSize` and shifts the origin so the opposite
+    // edge stays anchored. When unclamped that shift is exactly d/2; when the scale is
+    // clamped it is derived from the actual scale change instead.
+    if (direction.includes(Direction.E) || direction.includes(Direction.W)) {
+      const sign = direction.includes(Direction.E) ? 1 : -1;
+      const raw = element.scaleX + (sign * dx) / width;
+      const newScaleX = Math.max(MIN_SCALE, raw);
+      element.x += newScaleX === raw ? dx / 2 : (sign * (newScaleX - element.scaleX) * width) / 2;
+      element.scaleX = newScaleX;
+    }
 
-    switch (direction) {
-      case Direction.NW:
-        element.x += dx;
-        element.y += dy;
-        element.scaleX = Math.max(MIN_SCALE, element.scaleX - scaleXChange);
-        element.scaleY = Math.max(MIN_SCALE, element.scaleY - scaleYChange);
-        break;
-      case Direction.N:
-        element.y += dy;
-        element.scaleY = Math.max(MIN_SCALE, element.scaleY - scaleYChange);
-        break;
-      case Direction.NE:
-        element.y += dy;
-        element.scaleX = Math.max(MIN_SCALE, element.scaleX + scaleXChange);
-        element.scaleY = Math.max(MIN_SCALE, element.scaleY - scaleYChange);
-        break;
-      case Direction.E:
-        element.scaleX = Math.max(MIN_SCALE, element.scaleX + scaleXChange);
-        break;
-      case Direction.SE:
-        element.scaleX = Math.max(MIN_SCALE, element.scaleX + scaleXChange);
-        element.scaleY = Math.max(MIN_SCALE, element.scaleY + scaleYChange);
-        break;
-      case Direction.S:
-        element.scaleY = Math.max(MIN_SCALE, element.scaleY + scaleYChange);
-        break;
-      case Direction.SW:
-        element.x += dx;
-        element.scaleX = Math.max(MIN_SCALE, element.scaleX - scaleXChange);
-        element.scaleY = Math.max(MIN_SCALE, element.scaleY + scaleYChange);
-        break;
-      case Direction.W:
-        element.x += dx;
-        element.scaleX = Math.max(MIN_SCALE, element.scaleX - scaleXChange);
-        break;
+    if (direction.includes(Direction.S) || direction.includes(Direction.N)) {
+      const sign = direction.includes(Direction.S) ? 1 : -1;
+      const raw = element.scaleY + (sign * dy) / height;
+      const newScaleY = Math.max(MIN_SCALE, raw);
+      element.y += newScaleY === raw ? dy / 2 : (sign * (newScaleY - element.scaleY) * height) / 2;
+      element.scaleY = newScaleY;
     }
 
     return element;
   }
 
   getBounds(element: TextElement): Bounds {
-    const { text, x, y, scaleX, scaleY, style } = element;
-    const fontSize = style.fontSize ?? defaultTextElementStyle.fontSize ?? 16;
-    const lineHeight = fontSize * 1.2; // Match the line-height from rendering
-    const approximateCharWidth = fontSize * 0.6; // Slightly more accurate char width
+    const { x, y, scaleX, scaleY } = element;
+    const { width: naturalWidth, height: naturalHeight, ox, oy } = getNaturalMetrics(element);
 
-    const lines = text.split('\n');
-    const maxChars = lines.reduce((max, line) => Math.max(max, line.length), 0);
-
-    // Calculate actual width and height
-    const width = approximateCharWidth * maxChars * scaleX || fontSize * scaleX; // Minimum width
-    const height = lineHeight * lines.length * scaleY || fontSize * scaleY; // Minimum height
-
-    // SVG text y coordinate is at the baseline, so we need to offset upward
-    // The first line starts approximately 0.8 * fontSize above the baseline
-    const baselineOffset = fontSize * 0.8 * scaleY;
+    // Scale is applied around the fill-box center (ox, oy), matching the SVG render.
+    const width = naturalWidth * scaleX;
+    const height = naturalHeight * scaleY;
+    const minX = x + ox - width / 2;
+    const minY = y + oy - height / 2;
 
     return {
-      minX: x,
-      minY: y - baselineOffset,
-      maxX: x + width,
-      maxY: y - baselineOffset + height,
+      minX,
+      minY,
+      maxX: minX + width,
+      maxY: minY + height,
       width,
       height,
     };

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/select-tool.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/select-tool.test.ts
@@ -1196,14 +1196,20 @@ describe('SelectTool', () => {
       expect(selectTool.getCurrentHandle()).toBe(Direction.SE);
     });
 
-    it('should apply rotation to resize direction', () => {
-      const mockTarget = { id: `${SELECTOR_GRIP_RESIZE}_n`, getAttribute: jest.fn() };
+    it('keeps the resize direction glued to the grip when the element is rotated', () => {
+      // The selection box and its grips live inside #selectorParentGroup, which rotates
+      // with the element, so each grip stays glued to its own local corner. The resize
+      // direction must therefore be the grip's own static direction — NOT a rotation-
+      // remapped one — otherwise dragging a grip resizes a different corner than the one
+      // under the cursor (the rotated grip and the handler's delta un-rotation would
+      // double-count the rotation).
+      const mockTarget = { id: `${SELECTOR_GRIP_RESIZE}_nw`, getAttribute: jest.fn() };
       (getMouseTarget as jest.Mock).mockReturnValue(mockTarget);
-      (getRotatedDirection as jest.Mock).mockReturnValue(Direction.NE); // Rotated direction
+      (getRotatedDirection as jest.Mock).mockReturnValue(Direction.NE); // a remap would be wrong here
 
       apiService.getSelectedElements = jest
         .fn()
-        .mockReturnValue([{ id: '1', rotation: 45, type: ElementType.Rectangle, x: 0, y: 0, width: 100, height: 100 }]);
+        .mockReturnValue([{ id: '1', rotation: 90, type: ElementType.Rectangle, x: 0, y: 0, width: 100, height: 100 }]);
 
       const mockGetBounds = jest.fn().mockReturnValue({
         minX: 0,
@@ -1220,8 +1226,8 @@ describe('SelectTool', () => {
       const event = createMockPointerInfo({ x: 100, y: 100, eventType: 'pointerdown' });
       selectTool.handlePointerDown(event);
 
-      expect(getRotatedDirection).toHaveBeenCalledWith(Direction.N, 45);
-      expect(selectTool.getCurrentHandle()).toBe(Direction.NE);
+      expect(getRotatedDirection).not.toHaveBeenCalled();
+      expect(selectTool.getCurrentHandle()).toBe(Direction.NW);
     });
 
     it('should return default direction for invalid handle ID', () => {

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/select-tool.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/select-tool.test.ts
@@ -433,7 +433,9 @@ describe('SelectTool', () => {
       selectTool.handlePointerMove(event);
       flushRAF();
 
-      expect(getSnappedOffset).toHaveBeenCalledWith(50, 150);
+      // Resize tracks the cursor absolutely: for the N handle the snapped offset is
+      // (cursor.x − bounds.maxX for E/W → 0 here, cursor.y − bounds.minY = 200).
+      expect(getSnappedOffset).toHaveBeenCalledWith(0, 200);
       expect(apiService.transformSelectedElements).toHaveBeenCalled();
     });
 

--- a/projects/ng-whiteboard/src/lib/core/tools/select-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/select-tool.ts
@@ -8,14 +8,17 @@ import { Direction, ElementType, Point, PointerInfo, SnapResult, ToolType, White
 import { getMouseTarget } from '../utils/dom';
 import {
   calculateAngle,
-  getRotatedDirection,
   getSnappedOffset,
   isElementInSelectionBox,
   normalizeAngle,
   rotatePointAroundCenter,
 } from '../utils/geometry';
 import { getElementBounds } from '../utils/dom/element';
-import { getCombinedScreenBounds } from '../utils/geometry/transform-utils';
+import {
+  getCombinedScreenBounds,
+  getRotatedChildScale,
+  getRotatedResizeAnchor,
+} from '../utils/geometry/transform-utils';
 
 import { BaseTool } from './base-tool';
 import { CursorType } from '../types/cursors';
@@ -386,12 +389,16 @@ export class SelectTool extends BaseTool {
         // bbox corners so the dragged handle edge follows the cursor exactly,
         // regardless of where inside the grip the user clicked.
         const naturalBounds = getElementUtil(initialElement.type).getBounds(initialElement);
-        localDx = handle.includes(Direction.E) ? currentPoint.x - naturalBounds.maxX
-                : handle.includes(Direction.W) ? currentPoint.x - naturalBounds.minX
-                : 0;
-        localDy = handle.includes(Direction.S) ? currentPoint.y - naturalBounds.maxY
-                : handle.includes(Direction.N) ? currentPoint.y - naturalBounds.minY
-                : 0;
+        localDx = handle.includes(Direction.E)
+          ? currentPoint.x - naturalBounds.maxX
+          : handle.includes(Direction.W)
+          ? currentPoint.x - naturalBounds.minX
+          : 0;
+        localDy = handle.includes(Direction.S)
+          ? currentPoint.y - naturalBounds.maxY
+          : handle.includes(Direction.N)
+          ? currentPoint.y - naturalBounds.minY
+          : 0;
       }
 
       let snappedX = localDx;
@@ -412,33 +419,14 @@ export class SelectTool extends BaseTool {
           const initial = this.initialElementStates.get(el.id);
           if (!initial) return el;
 
+          // For a rotated element the element renders rotated around its fill-box center,
+          // so pin the anchor corner (opposite the dragged handle) in world space using
+          // that same center. Computing it before and after the resize and shifting by the
+          // difference keeps the opposite corner fixed instead of drifting.
           let anchorPointBefore: Point | null = null;
-              if (initial.rotation && initial.rotation !== 0) {
+          if (initial.rotation && initial.rotation !== 0) {
             const initialBounds = getElementUtil(initial.type).getBounds(initial);
-            const localMinX = initialBounds.minX - initial.x;
-            const localMinY = initialBounds.minY - initial.y;
-            const width = initialBounds.width;
-            const height = initialBounds.height;
-
-            let anchorLocalX = 0,
-              anchorLocalY = 0;
-
-            if (handle.includes(Direction.N)) anchorLocalY = localMinY + height;
-            else if (handle.includes(Direction.S)) anchorLocalY = localMinY;
-            else anchorLocalY = localMinY + height / 2;
-
-            if (handle.includes(Direction.W)) anchorLocalX = localMinX + width;
-            else if (handle.includes(Direction.E)) anchorLocalX = localMinX;
-            else anchorLocalX = localMinX + width / 2;
-
-            const angleRad = (initial.rotation * Math.PI) / 180;
-            const cos = Math.cos(angleRad);
-            const sin = Math.sin(angleRad);
-
-            anchorPointBefore = {
-              x: initial.x + (anchorLocalX * cos - anchorLocalY * sin),
-              y: initial.y + (anchorLocalX * sin + anchorLocalY * cos),
-            };
+            anchorPointBefore = getRotatedResizeAnchor(initialBounds, handle, initial.rotation);
           }
 
           const elementUtil = getElementUtil(initial.type);
@@ -446,31 +434,7 @@ export class SelectTool extends BaseTool {
 
           if (initial.rotation && initial.rotation !== 0 && anchorPointBefore) {
             const resizedBounds = getElementUtil(resized.type).getBounds(resized);
-            const resizedLocalMinX = resizedBounds.minX - resized.x;
-            const resizedLocalMinY = resizedBounds.minY - resized.y;
-            const width = resizedBounds.width;
-            const height = resizedBounds.height;
-
-            let anchorLocalX = 0,
-              anchorLocalY = 0;
-
-            if (handle.includes(Direction.N)) anchorLocalY = resizedLocalMinY + height;
-            else if (handle.includes(Direction.S)) anchorLocalY = resizedLocalMinY;
-            else anchorLocalY = resizedLocalMinY + height / 2;
-
-            if (handle.includes(Direction.W)) anchorLocalX = resizedLocalMinX + width;
-            else if (handle.includes(Direction.E)) anchorLocalX = resizedLocalMinX;
-            else anchorLocalX = resizedLocalMinX + width / 2;
-
-            const rotation = resized.rotation ?? 0;
-            const angleRad = (rotation * Math.PI) / 180;
-            const cos = Math.cos(angleRad);
-            const sin = Math.sin(angleRad);
-
-            const anchorPointAfter = {
-              x: resized.x + (anchorLocalX * cos - anchorLocalY * sin),
-              y: resized.y + (anchorLocalX * sin + anchorLocalY * cos),
-            };
+            const anchorPointAfter = getRotatedResizeAnchor(resizedBounds, handle, resized.rotation ?? 0);
 
             resized.x += anchorPointBefore.x - anchorPointAfter.x;
             resized.y += anchorPointBefore.y - anchorPointAfter.y;
@@ -567,27 +531,38 @@ export class SelectTool extends BaseTool {
           return element;
         }
 
-        const relX = initialElement.x - anchorX;
-        const relY = initialElement.y - anchorY;
+        // Project the group scale onto the child's own axes so rotated children scale
+        // along their orientation instead of stretching diagonally out of the box.
+        const childScale = getRotatedChildScale(finalScaleX, finalScaleY, initialElement.rotation ?? 0);
 
-        const newRelX = relX * finalScaleX;
-        const newRelY = relY * finalScaleY;
-
-        const scaledX = anchorX + newRelX;
-        const scaledY = anchorY + newRelY;
+        const hasSize =
+          'width' in initialElement &&
+          initialElement.width !== undefined &&
+          'height' in initialElement &&
+          initialElement.height !== undefined;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const updates: any = {
-          ...element,
-          x: scaledX,
-          y: scaledY,
-        };
+        const updates: any = { ...element };
 
-        if ('width' in initialElement && initialElement.width !== undefined) {
-          updates.width = initialElement.width * Math.abs(finalScaleX);
-        }
-        if ('height' in initialElement && initialElement.height !== undefined) {
-          updates.height = initialElement.height * Math.abs(finalScaleY);
+        if (hasSize) {
+          // Scale the child's center about the anchor with the group scale, then re-derive
+          // the origin from the projected-scaled size. Origin-only scaling would shift a
+          // rotated child whenever its size scale differs from the group scale.
+          const w0 = initialElement.width as number;
+          const h0 = initialElement.height as number;
+          const newWidthEl = w0 * childScale.scaleX;
+          const newHeightEl = h0 * childScale.scaleY;
+          const centerX = initialElement.x + w0 / 2;
+          const centerY = initialElement.y + h0 / 2;
+          const newCenterX = anchorX + (centerX - anchorX) * finalScaleX;
+          const newCenterY = anchorY + (centerY - anchorY) * finalScaleY;
+          updates.x = newCenterX - newWidthEl / 2;
+          updates.y = newCenterY - newHeightEl / 2;
+          updates.width = newWidthEl;
+          updates.height = newHeightEl;
+        } else {
+          updates.x = anchorX + (initialElement.x - anchorX) * finalScaleX;
+          updates.y = anchorY + (initialElement.y - anchorY) * finalScaleY;
         }
 
         if (initialElement.style?.strokeWidth) {
@@ -1003,12 +978,11 @@ export class SelectTool extends BaseTool {
       baseDirection = staticDirectionStr as Direction;
     }
 
-    const selectedElements = this.apiService.getSelectedElements();
-    if (selectedElements.length > 0) {
-      const rotation = selectedElements[0].rotation || 0;
-      return getRotatedDirection(baseDirection, rotation);
-    }
-
+    // The selection box and its grips render inside #selectorParentGroup, which rotates
+    // with the element, so each grip stays glued to its own local corner. The resize
+    // direction is therefore the grip's own (static) direction — the handler un-rotates
+    // the cursor delta into local space, so applying a rotation remap here would
+    // double-count the rotation and resize the wrong corner.
     return baseDirection;
   }
 }

--- a/projects/ng-whiteboard/src/lib/core/tools/select-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/select-tool.ts
@@ -15,6 +15,7 @@ import {
   rotatePointAroundCenter,
 } from '../utils/geometry';
 import { getElementBounds } from '../utils/dom/element';
+import { getCombinedScreenBounds } from '../utils/geometry/transform-utils';
 
 import { BaseTool } from './base-tool';
 import { CursorType } from '../types/cursors';
@@ -368,18 +369,29 @@ export class SelectTool extends BaseTool {
       const initialElement = this.initialElementStates.get(element.id);
       if (!initialElement) return;
 
-      const dx = currentPoint.x - this.startPoint.x;
-      const dy = currentPoint.y - this.startPoint.y;
-
-      let localDx = dx;
-      let localDy = dy;
+      let localDx: number;
+      let localDy: number;
 
       if (element.rotation && element.rotation !== 0) {
+        // For rotated elements keep the delta-from-click approach and un-rotate to local space.
+        const rawDx = currentPoint.x - this.startPoint.x;
+        const rawDy = currentPoint.y - this.startPoint.y;
         const angleRad = (-element.rotation * Math.PI) / 180;
         const cos = Math.cos(angleRad);
         const sin = Math.sin(angleRad);
-        localDx = dx * cos - dy * sin;
-        localDy = dx * sin + dy * cos;
+        localDx = rawDx * cos - rawDy * sin;
+        localDy = rawDx * sin + rawDy * cos;
+      } else {
+        // Absolute cursor tracking: compute dx/dy relative to the initial natural
+        // bbox corners so the dragged handle edge follows the cursor exactly,
+        // regardless of where inside the grip the user clicked.
+        const naturalBounds = getElementUtil(initialElement.type).getBounds(initialElement);
+        localDx = handle.includes(Direction.E) ? currentPoint.x - naturalBounds.maxX
+                : handle.includes(Direction.W) ? currentPoint.x - naturalBounds.minX
+                : 0;
+        localDy = handle.includes(Direction.S) ? currentPoint.y - naturalBounds.maxY
+                : handle.includes(Direction.N) ? currentPoint.y - naturalBounds.minY
+                : 0;
       }
 
       let snappedX = localDx;
@@ -401,21 +413,23 @@ export class SelectTool extends BaseTool {
           if (!initial) return el;
 
           let anchorPointBefore: Point | null = null;
-          if (initial.rotation && initial.rotation !== 0) {
-            const initialAny = initial as unknown as Record<string, unknown>;
-            const width = (initialAny['width'] as number) || (initialAny['rx'] as number) * 2 || 0;
-            const height = (initialAny['height'] as number) || (initialAny['ry'] as number) * 2 || 0;
+              if (initial.rotation && initial.rotation !== 0) {
+            const initialBounds = getElementUtil(initial.type).getBounds(initial);
+            const localMinX = initialBounds.minX - initial.x;
+            const localMinY = initialBounds.minY - initial.y;
+            const width = initialBounds.width;
+            const height = initialBounds.height;
 
             let anchorLocalX = 0,
               anchorLocalY = 0;
 
-            if (handle.includes(Direction.N)) anchorLocalY = height;
-            else if (handle.includes(Direction.S)) anchorLocalY = 0;
-            else anchorLocalY = height / 2;
+            if (handle.includes(Direction.N)) anchorLocalY = localMinY + height;
+            else if (handle.includes(Direction.S)) anchorLocalY = localMinY;
+            else anchorLocalY = localMinY + height / 2;
 
-            if (handle.includes(Direction.W)) anchorLocalX = width;
-            else if (handle.includes(Direction.E)) anchorLocalX = 0;
-            else anchorLocalX = width / 2;
+            if (handle.includes(Direction.W)) anchorLocalX = localMinX + width;
+            else if (handle.includes(Direction.E)) anchorLocalX = localMinX;
+            else anchorLocalX = localMinX + width / 2;
 
             const angleRad = (initial.rotation * Math.PI) / 180;
             const cos = Math.cos(angleRad);
@@ -431,20 +445,22 @@ export class SelectTool extends BaseTool {
           const resized = elementUtil.resize({ ...initial }, handle, snappedX, snappedY);
 
           if (initial.rotation && initial.rotation !== 0 && anchorPointBefore) {
-            const resizedAny = resized as unknown as Record<string, unknown>;
-            const width = (resizedAny['width'] as number) || (resizedAny['rx'] as number) * 2 || 0;
-            const height = (resizedAny['height'] as number) || (resizedAny['ry'] as number) * 2 || 0;
+            const resizedBounds = getElementUtil(resized.type).getBounds(resized);
+            const resizedLocalMinX = resizedBounds.minX - resized.x;
+            const resizedLocalMinY = resizedBounds.minY - resized.y;
+            const width = resizedBounds.width;
+            const height = resizedBounds.height;
 
             let anchorLocalX = 0,
               anchorLocalY = 0;
 
-            if (handle.includes(Direction.N)) anchorLocalY = height;
-            else if (handle.includes(Direction.S)) anchorLocalY = 0;
-            else anchorLocalY = height / 2;
+            if (handle.includes(Direction.N)) anchorLocalY = resizedLocalMinY + height;
+            else if (handle.includes(Direction.S)) anchorLocalY = resizedLocalMinY;
+            else anchorLocalY = resizedLocalMinY + height / 2;
 
-            if (handle.includes(Direction.W)) anchorLocalX = width;
-            else if (handle.includes(Direction.E)) anchorLocalX = 0;
-            else anchorLocalX = width / 2;
+            if (handle.includes(Direction.W)) anchorLocalX = resizedLocalMinX + width;
+            else if (handle.includes(Direction.E)) anchorLocalX = resizedLocalMinX;
+            else anchorLocalX = resizedLocalMinX + width / 2;
 
             const rotation = resized.rotation ?? 0;
             const angleRad = (rotation * Math.PI) / 180;
@@ -908,18 +924,39 @@ export class SelectTool extends BaseTool {
       this.initialElementStates.set(element.id, { ...element });
     });
 
-    const allBounds = selectedElements.map((el) => getElementBounds(el));
-    const minX = Math.min(...allBounds.map((b) => b.minX));
-    const minY = Math.min(...allBounds.map((b) => b.minY));
-    const maxX = Math.max(...allBounds.map((b) => b.maxX));
-    const maxY = Math.max(...allBounds.map((b) => b.maxY));
-
-    this.initialBoundingBox = {
-      x: minX,
-      y: minY,
-      width: maxX - minX,
-      height: maxY - minY,
-    };
+    // Use the already-computed bounding box signal (which uses measureTextElementSvg
+    // for text elements) so that initialBoundingBox matches the displayed box exactly.
+    const currentBbox = this.apiService.getBoundingBoxSignal()();
+    if (currentBbox) {
+      this.initialBoundingBox = {
+        x: currentBbox.x,
+        y: currentBbox.y,
+        width: currentBbox.width,
+        height: currentBbox.height,
+      };
+    } else {
+      const combinedBounds = getCombinedScreenBounds(selectedElements);
+      if (combinedBounds) {
+        this.initialBoundingBox = {
+          x: combinedBounds.minX,
+          y: combinedBounds.minY,
+          width: combinedBounds.width,
+          height: combinedBounds.height,
+        };
+      } else {
+        const allBounds = selectedElements.map((el) => getElementBounds(el));
+        const minX = Math.min(...allBounds.map((b) => b.minX));
+        const minY = Math.min(...allBounds.map((b) => b.minY));
+        const maxX = Math.max(...allBounds.map((b) => b.maxX));
+        const maxY = Math.max(...allBounds.map((b) => b.maxY));
+        this.initialBoundingBox = {
+          x: minX,
+          y: minY,
+          width: maxX - minX,
+          height: maxY - minY,
+        };
+      }
+    }
   }
 
   private initializeRotation(event: PointerInfo): void {

--- a/projects/ng-whiteboard/src/lib/core/utils/geometry/transform-utils.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/utils/geometry/transform-utils.spec.ts
@@ -1,5 +1,10 @@
-import { WhiteboardElement } from '../../types';
-import { getCombinedScreenBounds, rotatePointAroundCenter } from './transform-utils';
+import { Bounds, Direction, WhiteboardElement } from '../../types';
+import {
+  getCombinedScreenBounds,
+  getRotatedChildScale,
+  getRotatedResizeAnchor,
+  rotatePointAroundCenter,
+} from './transform-utils';
 
 function createMockElement(overrides: Partial<WhiteboardElement> = {}): WhiteboardElement {
   return {
@@ -15,6 +20,77 @@ function createMockElement(overrides: Partial<WhiteboardElement> = {}): Whiteboa
 }
 
 describe('Transform Utils', () => {
+  describe('getRotatedChildScale', () => {
+    it('returns the group scale unchanged for an unrotated child', () => {
+      const s = getRotatedChildScale(1.5, 0.8, 0);
+      expect(s.scaleX).toBeCloseTo(1.5, 5);
+      expect(s.scaleY).toBeCloseTo(0.8, 5);
+    });
+
+    it('swaps the axes for a child rotated 90 degrees', () => {
+      const s = getRotatedChildScale(1.5, 0.8, 90);
+      expect(s.scaleX).toBeCloseTo(0.8, 5);
+      expect(s.scaleY).toBeCloseTo(1.5, 5);
+    });
+
+    it('keeps a uniform group scale uniform regardless of rotation', () => {
+      const s = getRotatedChildScale(2, 2, 37);
+      expect(s.scaleX).toBeCloseTo(2, 5);
+      expect(s.scaleY).toBeCloseTo(2, 5);
+    });
+
+    it('projects a non-uniform group scale onto the child axes at 45 degrees', () => {
+      // Both local axes see the same projection at 45°, so the child scales uniformly
+      // (no shear / diagonal overflow). hypot(2*cos45, 1*sin45) = sqrt(2.5) ≈ 1.5811.
+      const s = getRotatedChildScale(2, 1, 45);
+      expect(s.scaleX).toBeCloseTo(Math.sqrt(2.5), 5);
+      expect(s.scaleY).toBeCloseTo(Math.sqrt(2.5), 5);
+    });
+  });
+
+  describe('getRotatedResizeAnchor', () => {
+    const bounds: Bounds = { minX: 0, minY: 0, maxX: 200, maxY: 120, width: 200, height: 120 };
+
+    it('returns the opposite (SE) corner for the NW handle when unrotated', () => {
+      const anchor = getRotatedResizeAnchor(bounds, Direction.NW, 0);
+      expect(anchor.x).toBeCloseTo(200, 5);
+      expect(anchor.y).toBeCloseTo(120, 5);
+    });
+
+    it('rotates the anchor corner around the element center, not the origin', () => {
+      // Element renders rotated around its fill-box (geometry) center, so the SE anchor
+      // for the NW handle must be the SE corner rotated around the box center (100,60).
+      // rotate (200,120) around (100,60) by 90° -> (40,160).
+      const anchor = getRotatedResizeAnchor(bounds, Direction.NW, 90);
+      expect(anchor.x).toBeCloseTo(40, 5);
+      expect(anchor.y).toBeCloseTo(160, 5);
+    });
+
+    it('keeps the anchor corner pinned in world space across a resize (no drift)', () => {
+      // Drag NW: grow width by 80 (200 -> 280). The classic resize moves x by -80 (W edge).
+      const before: Bounds = { minX: 0, minY: 0, maxX: 200, maxY: 120, width: 200, height: 120 };
+      const after: Bounds = { minX: -80, minY: 0, maxX: 200, maxY: 120, width: 280, height: 120 };
+      const rotation = 37; // arbitrary
+
+      const anchorBefore = getRotatedResizeAnchor(before, Direction.NW, rotation);
+      // Re-anchor: shift the resized box so its anchor lands back on anchorBefore.
+      const anchorAfterRaw = getRotatedResizeAnchor(after, Direction.NW, rotation);
+      const dx = anchorBefore.x - anchorAfterRaw.x;
+      const dy = anchorBefore.y - anchorAfterRaw.y;
+      const corrected: Bounds = {
+        minX: after.minX + dx,
+        minY: after.minY + dy,
+        maxX: after.maxX + dx,
+        maxY: after.maxY + dy,
+        width: after.width,
+        height: after.height,
+      };
+      const anchorAfter = getRotatedResizeAnchor(corrected, Direction.NW, rotation);
+      expect(anchorAfter.x).toBeCloseTo(anchorBefore.x, 5);
+      expect(anchorAfter.y).toBeCloseTo(anchorBefore.y, 5);
+    });
+  });
+
   describe('rotatePointAroundCenter', () => {
     it('should rotate a point 90 degrees clockwise', () => {
       const point = { x: 10, y: 0 };

--- a/projects/ng-whiteboard/src/lib/core/utils/geometry/transform-utils.ts
+++ b/projects/ng-whiteboard/src/lib/core/utils/geometry/transform-utils.ts
@@ -1,4 +1,4 @@
-import { Point, Bounds, WhiteboardElement } from '../../types';
+import { Point, Bounds, Direction, WhiteboardElement } from '../../types';
 import { getElementBounds } from '../dom/element';
 
 /**
@@ -96,4 +96,49 @@ export function rotatePointAroundCenter(point: Point, center: Point, angleDegree
     x: center.x + dx * cos - dy * sin,
     y: center.y + dx * sin + dy * cos,
   };
+}
+
+/**
+ * World-space position of the resize anchor — the corner/edge that must stay pinned
+ * while dragging `handle` (i.e. the one opposite the dragged handle).
+ *
+ * The element renders rotated around its fill-box (geometry) center, which equals the
+ * center of `bounds`. So the anchor is the opposite corner rotated around that center —
+ * matching the render model `world(p) = center + R·(p − center)`. Computing it this way
+ * (rather than rotating around the element origin) keeps the anchor fixed in world space
+ * when the box dimensions change, so resizing a rotated element no longer drifts.
+ */
+/**
+ * Scale factors to apply to a rotated child's local width/height when a multi-selection
+ * group is resized by world-axis scale `(scaleX, scaleY)`.
+ *
+ * Applying the group's X-scale directly to a rotated child's local width stretches it
+ * along the child's own (rotated) axis, so a 45°-rotated box grows diagonally and spills
+ * out of the selection. Projecting the group scale onto the child's local axes instead
+ * scales each side by how much that side actually stretches in world space — shear-free,
+ * stays inside the box, reduces to `(scaleX, scaleY)` when unrotated and swaps at 90°.
+ */
+export function getRotatedChildScale(
+  scaleX: number,
+  scaleY: number,
+  rotationDegrees: number
+): { scaleX: number; scaleY: number } {
+  const rad = (rotationDegrees * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+
+  return {
+    scaleX: Math.hypot(scaleX * cos, scaleY * sin),
+    scaleY: Math.hypot(scaleX * sin, scaleY * cos),
+  };
+}
+
+export function getRotatedResizeAnchor(bounds: Bounds, handle: Direction, rotationDegrees: number): Point {
+  const centerX = (bounds.minX + bounds.maxX) / 2;
+  const centerY = (bounds.minY + bounds.maxY) / 2;
+
+  const anchorX = handle.includes(Direction.W) ? bounds.maxX : handle.includes(Direction.E) ? bounds.minX : centerX;
+  const anchorY = handle.includes(Direction.N) ? bounds.maxY : handle.includes(Direction.S) ? bounds.minY : centerY;
+
+  return rotatePointAroundCenter({ x: anchorX, y: anchorY }, { x: centerX, y: centerY }, rotationDegrees);
 }

--- a/projects/ng-whiteboard/src/lib/core/utils/geometry/transform-utils.ts
+++ b/projects/ng-whiteboard/src/lib/core/utils/geometry/transform-utils.ts
@@ -15,39 +15,31 @@ function getElementScreenBounds(element: WhiteboardElement): Bounds {
     return globalBounds;
   }
 
-  const localCenterX = globalBounds.width / 2;
-  const localCenterY = globalBounds.height / 2;
+  const centerX = globalBounds.minX + globalBounds.width / 2;
+  const centerY = globalBounds.minY + globalBounds.height / 2;
 
-  const localCorners: Point[] = [
-    { x: 0, y: 0 },
-    { x: globalBounds.width, y: 0 },
-    { x: globalBounds.width, y: globalBounds.height },
-    { x: 0, y: globalBounds.height },
+  const corners: Point[] = [
+    { x: globalBounds.minX, y: globalBounds.minY },
+    { x: globalBounds.maxX, y: globalBounds.minY },
+    { x: globalBounds.maxX, y: globalBounds.maxY },
+    { x: globalBounds.minX, y: globalBounds.maxY },
   ];
 
   const rotation = (element.rotation || 0) * (Math.PI / 180);
   const cos = Math.cos(rotation);
   const sin = Math.sin(rotation);
 
-  const rotatedCorners = localCorners.map((corner) => {
-    const dx = corner.x - localCenterX;
-    const dy = corner.y - localCenterY;
-    const rotatedX = dx * cos - dy * sin;
-    const rotatedY = dx * sin + dy * cos;
-
+  const rotatedCorners = corners.map((corner) => {
+    const dx = corner.x - centerX;
+    const dy = corner.y - centerY;
     return {
-      x: rotatedX + localCenterX,
-      y: rotatedY + localCenterY,
+      x: centerX + dx * cos - dy * sin,
+      y: centerY + dx * sin + dy * cos,
     };
   });
 
-  const globalCorners = rotatedCorners.map((corner) => ({
-    x: corner.x + element.x,
-    y: corner.y + element.y,
-  }));
-
-  const xs = globalCorners.map((p) => p.x);
-  const ys = globalCorners.map((p) => p.y);
+  const xs = rotatedCorners.map((p) => p.x);
+  const ys = rotatedCorners.map((p) => p.y);
 
   const minX = Math.min(...xs);
   const minY = Math.min(...ys);


### PR DESCRIPTION
## Summary

Fixes #338 — the selection bounding box did not line up with rotated/scaled elements.

Elements render with `transform-box: fill-box; transform-origin: center`, so rotation **and** scale pivot around the element's geometry center, not its local origin. The bounds and selection-box math instead scaled around the local origin and rotated around the AABB center, which drifted for text (origin offset from its center, plus scaleX/scaleY) and for rotated pen strokes in a multi-selection.

## Changes

Apply the true transform `world(p) = O + (x,y) + R·S·(p − O)` everywhere:

- **text-element**: `getBounds` and `resize` scale around the fill-box center via a shared `getNaturalMetrics` helper; restore multi-line height in the fallback.
- **selection.service**: position the scaled text selection box about its center.
- **transform-utils / select-tool**: keep AABB-center rotation and absolute cursor-tracking resize, consistent with the model above.
- Follow-up: keep rotated elements from drifting on resize.

## Notes

This branch also carries two unrelated CI commits (dependabot config, `format:check` base pin) per the agreed PR scope.

## Verification

Verified in a real browser: the selection box matches the rendered element pixel-for-pixel under combined scale + rotation. Library test suite passing.
