### PR TITLE
fix(ci): satisfy no-empty-function in demo test-setup

### DIFF
--- a/projects/demo/src/test-setup.ts
+++ b/projects/demo/src/test-setup.ts
@@ -6,12 +6,18 @@ setupZoneTestEnv({
 });
 
 class MockResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe(): void {
+    /* no-op */
+  }
+  unobserve(): void {
+    /* no-op */
+  }
+  disconnect(): void {
+    /* no-op */
+  }
 }
 
-global.ResizeObserver = MockResizeObserver as any;
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Summary

Fixes the red CI on `master` (and on every open PR built against it).

## Root cause

PR #336 merged a `MockResizeObserver` into `projects/demo/src/test-setup.ts`:

```ts
class MockResizeObserver {
  observe() {}
  unobserve() {}
  disconnect() {}
}
```

The three empty method bodies violate `@typescript-eslint/no-empty-function`, which `@nx/eslint-plugin`'s `flat/typescript` preset enables as an **error**. ESLint therefore exits non-zero, so the `Lint` step (`npx nx run-many -t lint`) fails — on `master` and on any PR whose CI builds against it (e.g. #353, #354), even though those PRs don't touch the file.

## Fix

- Give each mock method a no-op body so `no-empty-function` is satisfied.
- Replace `as any` with `as unknown as typeof ResizeObserver` to also clear the `no-explicit-any` warning on that line.

## Verification

`npx nx run-many -t lint --skip-nx-cache` → **0 errors** (warnings only). `demo` lint specifically: 0 errors.
