### PR TITLE
chore(ci): format claude workflow files with prettier

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,4 +37,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
@
## What
Run prettier on `.github/workflows/claude.yml` and `claude-code-review.yml` (removes trailing blank lines).

## Why
These files were committed without prettier formatting. `nx format:check --base=origin/master` only checks changed files, so the debt was invisible until Dependabot PR #355 (github-actions group) modified them — at which point format:check fails and blocks the PR. This unblocks #355.
@