### PR TITLE
fix(selection): exclude locked elements from selectAll

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/elements/selection.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/selection.service.spec.ts
@@ -371,6 +371,17 @@ describe('SelectionService', () => {
         const boundingBox = service.getBoundingBox();
         expect(boundingBox).not.toBeNull();
       });
+
+      it('should exclude locked elements', () => {
+        (elementsService.getElements as jest.Mock).mockReturnValue([
+          createMockElement('el-1', { x: 0, y: 0 }),
+          createMockElement('el-2', { x: 100, y: 100, locked: true }),
+          createMockElement('el-3', { x: 200, y: 200 }),
+        ]);
+        service.selectAll();
+        expect(service.getSelectionCount()).toBe(2);
+        expect(service.getSelectedElements().map((el) => el.id)).toEqual(['el-1', 'el-3']);
+      });
     });
 
     describe('selectElementsInArea()', () => {

--- a/projects/ng-whiteboard/src/lib/core/elements/selection.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/selection.service.ts
@@ -251,18 +251,21 @@ export class SelectionService {
       return;
     }
 
-    const allElements = this.getElementsFn();
-    const ids = new Set(allElements.map((el) => el.id));
+    // Exclude locked elements, consistent with box selection (see SelectTool.handleBoxSelect,
+    // which filters `!element.locked`) and with every other select interaction that skips locked
+    // elements. Without this, Ctrl+A grabs locked elements and a following delete removes them.
+    const selectableElements = this.getElementsFn().filter((el) => !el.locked);
+    const ids = new Set(selectableElements.map((el) => el.id));
     this.selectedElementIdsSignal.set(ids);
 
     // Automatically activate select tool when elements are selected
-    if (allElements.length > 0) {
+    if (selectableElements.length > 0) {
       this.toolsService.setActiveTool(ToolType.Select);
     }
 
     this.updateBoundingBox();
 
-    this.eventBus.emit(WhiteboardEvent.ElementsSelected, allElements);
+    this.eventBus.emit(WhiteboardEvent.ElementsSelected, selectableElements);
   }
 
   /**


### PR DESCRIPTION
## What
`selectAll()` selected every element, including **locked** ones.

## Why
Box selection (`SelectTool.handleBoxSelect`) already filters out locked elements (`!element.locked`), and the other `SelectTool` interactions skip locked elements as well. `selectAll()` was the only selection path that ignored the lock, so Ctrl+A grabbed locked elements (e.g. a locked background image) and a following delete then removed them.

## Change
Filter out locked elements in `SelectionService.selectAll()`, consistent with box selection. The activate-tool check and the `ElementsSelected` event use the filtered list too.

## Test
Added a unit test in `selection.service.spec.ts` ("should exclude locked elements"). `nx test ng-whiteboard` passes (162 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)