### PR TITLE
feat(zoom): pan zoomToArea/zoomToElements to the target + add zoomToRegion

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/api/api.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/api/api.service.spec.ts
@@ -595,6 +595,11 @@ describe('ApiService', () => {
       expect(mockZoomService.zoomToSelection).toHaveBeenCalled();
     });
 
+    it('should zoom to region', () => {
+      service.zoomToRegion(10, 20, 100, 80);
+      expect(mockZoomService.zoomToRegion).toHaveBeenCalledWith(10, 20, 100, 80);
+    });
+
     it('should pan canvas', () => {
       service.pan(10, 20);
       expect(mockPanService.pan).toHaveBeenCalledWith(10, 20);

--- a/projects/ng-whiteboard/src/lib/core/api/api.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/api/api.service.ts
@@ -346,6 +346,10 @@ export class ApiService {
     this.zoomService.zoomToSelection();
   }
 
+  zoomToRegion(x: number, y: number, width: number, height: number): void {
+    this.zoomService.zoomToRegion(x, y, width, height);
+  }
+
   pan(dx: number, dy: number): void {
     this.panService.pan(dx, dy);
   }

--- a/projects/ng-whiteboard/src/lib/core/viewport/zoom.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/viewport/zoom.service.spec.ts
@@ -488,6 +488,41 @@ describe('ZoomService', () => {
 
       expect(mockCanvasService.getContainerDimensions).toHaveBeenCalled();
     });
+
+    it('should pan so the elements are centred (fullScreen content-level pan)', () => {
+      mockConfigService.getConfig.mockReturnValue({ ...mockConfig, fullScreen: true } as WhiteboardConfig);
+      mockElementsService.calculateElementsBounds.mockReturnValue({
+        x: 100,
+        y: 75,
+        width: 200,
+        height: 150,
+        centerX: 200,
+        centerY: 150,
+      });
+
+      // container 1000x800, margin 1 → zoom = min(1000/200, 800/150) clamped to MAX 5
+      // fullScreen pan: x = 800/(2·5) − 200 = −120; y = 600/(2·5) − 150 = −90
+      service.zoomToElements([{ id: '1' }] as WhiteboardElement[], 1, false);
+
+      expect(mockConfigService.updateConfig).toHaveBeenCalledWith({ x: -120, y: -90 });
+    });
+
+    it('should pan so the elements are centred (non-fullScreen, combining canvas offset)', () => {
+      // default mock: non-fullScreen, container 1000x800, canvas 800x600, canvasX/Y 0
+      mockElementsService.calculateElementsBounds.mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 300,
+        centerX: 200,
+        centerY: 150,
+      });
+
+      // zoom = min(800/400, 600/300) = 2 → x = (1000/2 − 0)/2 − 200 = 50; y = (800/2 − 0)/2 − 150 = 50
+      service.zoomToElements([{ id: '1' }] as WhiteboardElement[], 1, false);
+
+      expect(mockConfigService.updateConfig).toHaveBeenCalledWith({ x: 50, y: 50 });
+    });
   });
 
   describe('zoomToArea', () => {
@@ -516,6 +551,39 @@ describe('ZoomService', () => {
       service.zoomToArea(0, 0, 10, 10, 0.9, false);
 
       expect(mockConfigService.updateConfig).toHaveBeenCalled();
+    });
+
+    it('should ignore a degenerate (zero-size) area', () => {
+      service.zoomToArea(0, 0, 0, 0, 0.9, false);
+
+      expect(mockConfigService.updateConfig).not.toHaveBeenCalled();
+    });
+
+    it('should pan so the area is centred (fullScreen)', () => {
+      mockConfigService.getConfig.mockReturnValue({ ...mockConfig, fullScreen: true } as WhiteboardConfig);
+
+      // area (100,100,200,200) → centre (200,200); container 1000x800, margin 1
+      // zoom = min(1000/200, 800/200) = 4 → x = 800/(2·4) − 200 = −100; y = 600/(2·4) − 200 = −125
+      service.zoomToArea(100, 100, 200, 200, 1, false);
+
+      expect(mockConfigService.updateConfig).toHaveBeenCalledWith({ x: -100, y: -125 });
+    });
+  });
+
+  describe('zoomToRegion', () => {
+    it('should zoom into the region and pan to centre it (fullScreen)', () => {
+      mockConfigService.getConfig.mockReturnValue({ ...mockConfig, fullScreen: true } as WhiteboardConfig);
+
+      // same maths as zoomToArea, run instantly
+      service.zoomToRegion(100, 100, 200, 200, 1);
+
+      expect(mockConfigService.updateConfig).toHaveBeenCalledWith({ x: -100, y: -125 });
+    });
+
+    it('should ignore a degenerate (zero-size) region', () => {
+      service.zoomToRegion(0, 0, 0, 0);
+
+      expect(mockConfigService.updateConfig).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/ng-whiteboard/src/lib/core/viewport/zoom.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/viewport/zoom.service.ts
@@ -175,17 +175,20 @@ export class ZoomService implements OnDestroy {
     // Calculate zoom level to fit elements with padding
     const zoomX = (dimensions.width * margin) / bounds.width;
     const zoomY = (dimensions.height * margin) / bounds.height;
-    const targetZoom = Math.min(zoomX, zoomY);
+    const targetZoom = this.clampZoom(Math.min(zoomX, zoomY));
 
     if (animated) {
       this.animateToTarget(targetZoom, duration);
     } else {
       this.setInstant(targetZoom);
     }
+    // Pan so the elements are centred — setting the zoom level alone leaves the target
+    // anchored at the origin (most visible in fullScreen, where nothing repositions it).
+    this.panToCentre(bounds.centerX, bounds.centerY, targetZoom);
   }
 
   /**
-   * Zoom to fit a specific rectangular area.
+   * Zoom to fit a specific rectangular area, centred in the viewport.
    */
   zoomToArea(
     x: number,
@@ -196,15 +199,63 @@ export class ZoomService implements OnDestroy {
     animated = true,
     duration = 300
   ): void {
-    const canvasDimensions = this.canvasService.getCanvasDimensions();
-    const zoomX = (canvasDimensions.width * margin) / width;
-    const zoomY = (canvasDimensions.height * margin) / height;
-    const targetZoom = Math.min(zoomX, zoomY);
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    const { fullScreen } = this.getConfig();
+    const dimensions = fullScreen
+      ? this.canvasService.getContainerDimensions()
+      : this.canvasService.getCanvasDimensions();
+    const zoomX = (dimensions.width * margin) / width;
+    const zoomY = (dimensions.height * margin) / height;
+    const targetZoom = this.clampZoom(Math.min(zoomX, zoomY));
+
     if (animated) {
       this.animateToTarget(targetZoom, duration);
     } else {
       this.setInstant(targetZoom);
     }
+    this.panToCentre(x + width / 2, y + height / 2, targetZoom);
+  }
+
+  /**
+   * Pan so a world-space point lands at the centre of the viewport, at the given zoom.
+   *
+   * The two render modes need different math:
+   * - **fullScreen**: the viewBox is `0 0 W/zoom H/zoom` and only the content-level pan
+   *   (`config.x/y`) moves the view → `x = W/(2·zoom) − centreX`.
+   * - **non-fullScreen**: the canvas page is a zoom-scaled box at `(canvasX, canvasY)` in
+   *   the container, so the on-screen position combines that page offset with the content
+   *   pan → solve `canvasX + (centreX + x)·zoom = containerWidth/2` for `x`.
+   */
+  private panToCentre(centreX: number, centreY: number, zoom: number): void {
+    const { fullScreen, canvasWidth, canvasHeight, canvasX, canvasY } = this.getConfig();
+
+    if (fullScreen) {
+      this.configService.updateConfig({
+        x: canvasWidth / (2 * zoom) - centreX,
+        y: canvasHeight / (2 * zoom) - centreY,
+      });
+    } else {
+      const { width, height } = this.canvasService.getContainerDimensions();
+      this.configService.updateConfig({
+        x: (width / 2 - canvasX) / zoom - centreX,
+        y: (height / 2 - canvasY) / zoom - centreY,
+      });
+    }
+  }
+
+  /**
+   * Zoom into a rectangular region and centre it — the building block for a "marquee zoom"
+   * (drag a rectangle → zoom into it). Thin wrapper over `zoomToArea` (instant, so the pan
+   * matches the final zoom); ignores degenerate (zero-size) regions.
+   */
+  zoomToRegion(x: number, y: number, width: number, height: number, margin = this.DEFAULT_FIT_MARGIN): void {
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+    this.zoomToArea(x, y, width, height, margin, false);
   }
 
   /**


### PR DESCRIPTION
Follow-up to #392.

## What & why
The `zoomTo*` family computed the correct zoom *level* but never *panned* to bring
the target into view:

- `zoomToElements` / `zoomToArea` only set the zoom; the only repositioning — the
  `ZoomChange` listener's `centerCanvas` — recenters the whole canvas page
  (`canvasX/canvasY`), never the content pan (`config.x/y`).
- So `zoomToSelection` left a corner selection off-screen, and in fullScreen nothing
  panned at all (the viewBox stayed anchored at the origin).

Per your guidance I started by finishing `zoomToArea` / `zoomToElements`, then added
`zoomToRegion` on top. The `ToolType.ZoomArea` marquee tool will come in a separate PR.

## Approach
Pan the target to the viewport centre, mode-aware:

- **fullScreen** — content-level pan over the viewBox: `x = W/(2·zoom) − centreX`.
- **non-fullScreen** — combine the canvas page offset with the content pan: solve
  `canvasX + (centreX + x)·zoom = containerWidth/2` for `x`.

This also fixes `zoomToFit` / `zoomToSelection` (they delegate to `zoomToElements`).
`zoomToArea` now ignores degenerate (zero-size) areas and is mode-aware for the fit
dimensions too. `zoomToRegion(x, y, w, h)` is a thin building block (instant, so the
pan matches the final zoom) and is exposed on the public API.

## Behaviour change
`zoomToFit` / `zoomToSelection` / `zoomToArea` now pan to the target (previously they
only changed the zoom level). This is the intended fix from #392 (option c), flagging
it since it changes their observable behaviour.

## Tests
Unit tests for the pan in both modes (`zoomToElements` / `zoomToArea` / `zoomToRegion`).
Full lib suite green.

---

Thanks for ng-whiteboard — it's a genuinely well-built library, and the clean
service/config separation made this easy to extend. Appreciate the quick, thoughtful
feedback on the discussion. 🙏