### PR TITLE
feat(config): selectAfterDraw — configurable post-draw select & tool behavior

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/api/api.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/api/api.service.spec.ts
@@ -1075,4 +1075,27 @@ describe('ApiService', () => {
       expect(result).toEqual({ x: 100, y: 200 });
     });
   });
+
+  describe('finalizeDraw', () => {
+    const element = { id: 'e1', type: ElementType.Rectangle, selectAfterDraw: true } as unknown as WhiteboardElement;
+
+    it('selects the element and activates the Select tool when selectAfterDraw resolves true', () => {
+      mockConfigService.resolveSelectAfterDraw.mockReturnValue(true);
+
+      service.finalizeDraw(element);
+
+      expect(mockConfigService.resolveSelectAfterDraw).toHaveBeenCalledWith(ElementType.Rectangle, true);
+      expect(mockSelectionService.selectElements).toHaveBeenCalledWith(['e1']);
+      expect(mockToolsService.setActiveTool).toHaveBeenCalledWith(ToolType.Select);
+    });
+
+    it('does nothing (keeps the drawing tool) when selectAfterDraw resolves false', () => {
+      mockConfigService.resolveSelectAfterDraw.mockReturnValue(false);
+
+      service.finalizeDraw(element);
+
+      expect(mockSelectionService.selectElements).not.toHaveBeenCalled();
+      expect(mockToolsService.setActiveTool).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/projects/ng-whiteboard/src/lib/core/api/api.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/api/api.service.ts
@@ -149,6 +149,20 @@ export class ApiService {
     this.selectionService.selectElements(elementsOrIds, append);
   }
 
+  /**
+   * Apply the post-draw behaviour for a freshly drawn element: when `selectAfterDraw` resolves
+   * true (config override or the element's own default), select it and activate the Select tool;
+   * when false, leave it unselected so the drawing tool stays active. Called by the tools on
+   * pointer-up — the single place the "select + switch to Select vs keep drawing" decision lives.
+   */
+  finalizeDraw(element: WhiteboardElement): void {
+    const select = this.configService.resolveSelectAfterDraw(element.type, element.selectAfterDraw ?? false);
+    if (select) {
+      this.selectionService.selectElements([element.id]);
+      this.toolsService.setActiveTool(ToolType.Select);
+    }
+  }
+
   deselectElement(elementOrId: WhiteboardElement | string): void {
     this.selectionService.deselectElement(elementOrId);
   }

--- a/projects/ng-whiteboard/src/lib/core/config/config.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/config/config.service.spec.ts
@@ -1,5 +1,5 @@
 import { EventBusService } from '../event-bus/event-bus.service';
-import { WhiteboardEvent, LineCap, LineJoin, PenType } from '../types';
+import { WhiteboardEvent, LineCap, LineJoin, PenType, ElementType } from '../types';
 import { ConfigService } from './config.service';
 
 describe('ConfigService', () => {
@@ -520,6 +520,28 @@ describe('ConfigService', () => {
     it('should handle transparent fill', () => {
       service.updateConfig({ fill: 'transparent' });
       expect(service.getConfig().fill).toBe('transparent');
+    });
+  });
+
+  describe('resolveSelectAfterDraw', () => {
+    it('falls back to the element default when the config is omitted', () => {
+      expect(service.resolveSelectAfterDraw(ElementType.Pen, false)).toBe(false);
+      expect(service.resolveSelectAfterDraw(ElementType.Rectangle, true)).toBe(true);
+    });
+
+    it('applies a global boolean to every type', () => {
+      service.updateConfig({ selectAfterDraw: false }, false);
+      expect(service.resolveSelectAfterDraw(ElementType.Rectangle, true)).toBe(false);
+
+      service.updateConfig({ selectAfterDraw: true }, false);
+      expect(service.resolveSelectAfterDraw(ElementType.Pen, false)).toBe(true);
+    });
+
+    it('applies per-type overrides and falls back to the element default for missing types', () => {
+      service.updateConfig({ selectAfterDraw: { [ElementType.Pen]: true } }, false);
+      expect(service.resolveSelectAfterDraw(ElementType.Pen, false)).toBe(true); // overridden
+      expect(service.resolveSelectAfterDraw(ElementType.Rectangle, true)).toBe(true); // missing → default
+      expect(service.resolveSelectAfterDraw(ElementType.Rectangle, false)).toBe(false); // missing → default
     });
   });
 });

--- a/projects/ng-whiteboard/src/lib/core/config/config.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/config/config.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import {
+  ElementType,
   LineCap,
   LineJoin,
   WhiteboardConfig,
@@ -117,6 +118,18 @@ export class ConfigService {
 
   getConfig(): Readonly<WhiteboardConfig> {
     return this.config();
+  }
+
+  /**
+   * Resolve the post-draw "select after draw" behaviour for an element type. Honours the
+   * `selectAfterDraw` config (global boolean or per-type object); falls back to the element's
+   * own default when the config is omitted (or has no entry for that type).
+   */
+  resolveSelectAfterDraw(type: ElementType, fallback: boolean): boolean {
+    const cfg = this.config().selectAfterDraw;
+    if (cfg === undefined) return fallback;
+    if (typeof cfg === 'boolean') return cfg;
+    return cfg[type] ?? fallback;
   }
 
   getConfigSignal() {

--- a/projects/ng-whiteboard/src/lib/core/elements/selection.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/selection.service.spec.ts
@@ -240,9 +240,9 @@ describe('SelectionService', () => {
         expect(eventBusService.emit).toHaveBeenCalledWith(WhiteboardEvent.ElementsSelected, expect.any(Array));
       });
 
-      it('should activate select tool when selecting elements', () => {
+      it('should NOT activate the select tool (selection is selection-state only now)', () => {
         service.selectElements('el-1');
-        expect(toolsService.setActiveTool).toHaveBeenCalledWith(ToolType.Select);
+        expect(toolsService.setActiveTool).not.toHaveBeenCalled();
       });
 
       it('should update bounding box', () => {

--- a/projects/ng-whiteboard/src/lib/core/elements/selection.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/elements/selection.service.ts
@@ -86,6 +86,8 @@ export class SelectionService {
     const pastedElements = this.clipboardService.paste();
     if (pastedElements.length > 0) {
       this.selectElements(pastedElements);
+      // Pasting is a manipulate intent → drop into Select so the pasted elements can be moved.
+      this.toolsService.setActiveTool(ToolType.Select);
     }
   }
 
@@ -96,6 +98,7 @@ export class SelectionService {
     const duplicatedElements = this.clipboardService.duplicateElements(selectedElements);
     if (duplicatedElements.length > 0) {
       this.selectElements(duplicatedElements);
+      this.toolsService.setActiveTool(ToolType.Select);
     }
   }
 
@@ -167,9 +170,10 @@ export class SelectionService {
 
     this.selectedElementIdsSignal.set(new Set(newSelection));
 
-    if (newSelection.length > 0) {
-      this.toolsService.setActiveTool(ToolType.Select);
-    }
+    // NOTE: selecting no longer auto-activates the Select tool. That decision belongs to the
+    // caller's context — the post-draw flow resolves it via `selectAfterDraw` (see
+    // ApiService.finalizeDraw), and explicit user-select paths (toggleSelection, selectAll,
+    // paste/duplicate) switch on their own. Keeps selectElements() focused on selection state.
 
     // Get the updated selection elements after group expansion
     const fullSelectionElements = this.getSelectedElements();

--- a/projects/ng-whiteboard/src/lib/core/input/io.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/input/io.service.ts
@@ -59,7 +59,9 @@ export class IOService {
 
       this.elementsService.addElements([element]);
 
-      if (element.selectAfterDraw) {
+      // Config-aware select-after-draw (see ConfigService.resolveSelectAfterDraw). Selection no
+      // longer forces the Select tool — selecting is selection state only now.
+      if (this.configService.resolveSelectAfterDraw(element.type, element.selectAfterDraw ?? false)) {
         this.selectionService.selectElements([element.id]);
       }
 

--- a/projects/ng-whiteboard/src/lib/core/testing/test-helpers.ts
+++ b/projects/ng-whiteboard/src/lib/core/testing/test-helpers.ts
@@ -166,6 +166,7 @@ export function createMockApiService() {
     deselectElements: noop,
     clearSelection: noop,
     getSelectedElements: noopWithReturn([]),
+    finalizeDraw: noop,
 
     // Tool operations
     setTool: noop,

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/arrow-tool.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/arrow-tool.test.ts
@@ -58,6 +58,7 @@ describe('ArrowTool', () => {
     apiService.getNextZIndex = jest.fn().mockReturnValue(1);
     apiService.getActiveLayerId = jest.fn().mockReturnValue('layer-1');
     apiService.selectElements = jest.fn();
+    apiService.finalizeDraw = jest.fn();
 
     arrowTool = new ArrowTool(apiService as unknown as ApiService);
     arrowTool.activate();
@@ -521,8 +522,8 @@ describe('ArrowTool', () => {
     });
   });
 
-  describe('handlePointerUp with selectAfterDraw', () => {
-    it('should select the element if selectAfterDraw is true', () => {
+  describe('handlePointerUp post-draw', () => {
+    it('should delegate to finalizeDraw with the drawn element (select decision lives there)', () => {
       arrowTool.element = {
         id: 'a1',
         x1: 0,
@@ -535,16 +536,16 @@ describe('ArrowTool', () => {
 
       arrowTool.handlePointerUp();
 
-      expect(apiService.selectElements).toHaveBeenCalledWith(['a1']);
+      expect(apiService.finalizeDraw).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
     });
 
-    it('should not select the element if selectAfterDraw is falsy', () => {
+    it('should call finalizeDraw regardless of the element selectAfterDraw flag', () => {
       arrowTool.element = { id: 'a1', x1: 0, y1: 0, x2: 100, y2: 100 } as unknown as ArrowElement;
       arrowTool.startPoint = { x: 0, y: 0 };
 
       arrowTool.handlePointerUp();
 
-      expect(apiService.selectElements).not.toHaveBeenCalled();
+      expect(apiService.finalizeDraw).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
     });
   });
 

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/pen-tool.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/pen-tool.spec.ts
@@ -33,6 +33,7 @@ describe('PenTool', () => {
     apiService.commitDraft = jest.fn();
     apiService.commitDraftElements = jest.fn();
     apiService.selectElements = jest.fn();
+    apiService.finalizeDraw = jest.fn();
     apiService.getConfig = jest.fn().mockReturnValue(config);
     apiService.getCurrentLayer = jest.fn().mockReturnValue('layer1');
 
@@ -153,7 +154,7 @@ describe('PenTool', () => {
     expect(penTool.element).toBeNull();
   });
 
-  it('should select the element after drawing if selectAfterDraw is true', () => {
+  it('should finalize the draw (post-draw select decision delegated) on pointer up', () => {
     penTool.element = {
       id: 'pen-1',
       points: [[100, 200]],
@@ -164,7 +165,7 @@ describe('PenTool', () => {
 
     penTool.handlePointerUp();
 
-    expect(apiService.selectElements).toHaveBeenCalledWith(['pen-1']);
+    expect(apiService.finalizeDraw).toHaveBeenCalledWith(expect.objectContaining({ id: 'pen-1' }));
     expect(penTool.element).toBeNull();
   });
 

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/rectangle-tool.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/rectangle-tool.test.ts
@@ -49,6 +49,7 @@ describe('RectangleTool', () => {
       getNextZIndex: jest.fn().mockReturnValue(1),
       getActiveLayerId: jest.fn().mockReturnValue('layer-1'),
       selectElements: jest.fn(),
+      finalizeDraw: jest.fn(),
     } as unknown as ApiService;
 
     rectangleTool = new RectangleTool(apiService);

--- a/projects/ng-whiteboard/src/lib/core/tools/__tests__/text-tool.test.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/__tests__/text-tool.test.ts
@@ -80,6 +80,7 @@ describe('TextTool', () => {
       getNextZIndex: jest.fn().mockReturnValue(1),
       getActiveLayerId: jest.fn().mockReturnValue('layer-1'),
       elementExists: jest.fn().mockReturnValue(false),
+      finalizeDraw: jest.fn(),
     } as unknown as ApiService;
 
     textTool = new TextTool(apiService);

--- a/projects/ng-whiteboard/src/lib/core/tools/arrow-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/arrow-tool.ts
@@ -207,9 +207,7 @@ export class ArrowTool extends BaseTool {
 
       this.apiService.commitDraftElements();
 
-      if (element.selectAfterDraw) {
-        this.apiService.selectElements([element.id]);
-      }
+      this.apiService.finalizeDraw(element);
 
       this.startPoint = null;
       this.element = null;

--- a/projects/ng-whiteboard/src/lib/core/tools/ellipse-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/ellipse-tool.ts
@@ -73,10 +73,7 @@ export class EllipseTool extends BaseTool {
       const element = this.element;
       this.apiService.commitDraftElements();
 
-      // Handle selection based on element's selectAfterDraw property
-      if (element.selectAfterDraw) {
-        this.apiService.selectElements([element.id]);
-      }
+      this.apiService.finalizeDraw(element);
 
       this.startPoint = null;
       this.element = null;

--- a/projects/ng-whiteboard/src/lib/core/tools/line-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/line-tool.ts
@@ -82,10 +82,7 @@ export class LineTool extends BaseTool {
       const element = this.element;
       this.apiService.commitDraftElements();
 
-      // Handle selection based on element's selectAfterDraw property
-      if (element.selectAfterDraw) {
-        this.apiService.selectElements([element.id]);
-      }
+      this.apiService.finalizeDraw(element);
 
       this.startPoint = null;
       this.element = null;

--- a/projects/ng-whiteboard/src/lib/core/tools/pen-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/pen-tool.ts
@@ -101,9 +101,7 @@ export class PenTool extends BaseTool {
 
       this.apiService.commitDraftElements();
 
-      if (element.selectAfterDraw) {
-        this.apiService.selectElements([element.id]);
-      }
+      this.apiService.finalizeDraw(element);
 
       this.element = null;
     }

--- a/projects/ng-whiteboard/src/lib/core/tools/rectangle-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/rectangle-tool.ts
@@ -82,10 +82,7 @@ export class RectangleTool extends BaseTool {
       const element = this.element;
       this.apiService.commitDraftElements();
 
-      // Handle selection based on element's selectAfterDraw property
-      if (element.selectAfterDraw) {
-        this.apiService.selectElements([element.id]);
-      }
+      this.apiService.finalizeDraw(element);
 
       this.startPoint = null;
       this.element = null;

--- a/projects/ng-whiteboard/src/lib/core/tools/text-tool.ts
+++ b/projects/ng-whiteboard/src/lib/core/tools/text-tool.ts
@@ -154,9 +154,7 @@ export class TextTool extends BaseTool {
         if (!this.apiService.elementExists(this.textElement.id)) {
           this.apiService.addElements([this.textElement]);
 
-          if (this.textElement.selectAfterDraw) {
-            this.apiService.selectElements([this.textElement.id]);
-          }
+          this.apiService.finalizeDraw(this.textElement);
         }
       } else {
         this.apiService.removeElements([this.textElement]);

--- a/projects/ng-whiteboard/src/lib/core/types/config.ts
+++ b/projects/ng-whiteboard/src/lib/core/types/config.ts
@@ -1,4 +1,13 @@
-import { LineCap, LineJoin, PenType } from '.';
+import { ElementType, LineCap, LineJoin, PenType } from '.';
+
+/**
+ * Controls what happens after a tool finishes drawing an element:
+ * - `true` (for a tool): the new element is selected and the Select tool becomes active.
+ * - `false`: nothing is selected and the current drawing tool stays active (draw several in a row).
+ * - object: per-element-type overrides (e.g. `{ pen: false, rectangle: true }`).
+ * - omitted: falls back to each element's own `selectAfterDraw` default.
+ */
+export type SelectAfterDrawConfig = boolean | Partial<Record<ElementType, boolean>>;
 
 /**
  * Describes the type of arrowhead.
@@ -64,6 +73,12 @@ export interface WhiteboardConfig {
   penThrottlingThreshold: number;
   /** Arrow-specific configuration – heads, line style, size */
   arrowConfig: ArrowConfig;
+  /**
+   * Post-draw behaviour: whether a freshly drawn element gets selected (and the Select tool
+   * activated) or the drawing tool stays active. Global, per-element-type, or omitted to use
+   * each element's own default. See {@link SelectAfterDrawConfig}.
+   */
+  selectAfterDraw?: SelectAfterDrawConfig;
 }
 
 export interface EditorConfig {


### PR DESCRIPTION
Reworked from the original `keepToolActiveAfterDraw` flag per the discussion below — a single config property drives the whole post-draw workflow, instead of a second overlapping flag.

## What
- `selectAfterDraw?: boolean | Partial<Record<ElementType, boolean>>` on `WhiteboardConfig`:
  - `true` (for a tool) → the new element is selected and the Select tool becomes active.
  - `false` → nothing is selected and the current drawing tool stays active (draw several in a row).
  - object → per-element-type overrides (e.g. `{ pen: false, rectangle: true }`).
  - omitted → falls back to each element's own `selectAfterDraw` default (current behavior preserved).
- The tool-switch is moved **out of `selectElements()`** (now selection-state only) into the post-draw flow. `ApiService.finalizeDraw(element)` is the single decision point, resolving via `ConfigService.resolveSelectAfterDraw`. All six draw tools call it on pointer-up.

## Consequences of decoupling `selectElements()`
Since `selectElements()` no longer activates the Select tool, the callers that relied on that now handle it in their own context:
- `toggleSelection` / `selectAll` already switched on their own — unchanged.
- `paste` / `duplicate` now switch explicitly (manipulate intent).
- Image add (`IOService`) is made config-aware and selects **without** forcing the Select tool, consistent with the decoupling.

## Tests
- Updated the tool specs (they now delegate to `finalizeDraw`) and the `selectElements` switch test.
- Added coverage for `ConfigService.resolveSelectAfterDraw` (global / per-type / fallback) and `ApiService.finalizeDraw` (true → select + Select tool; false → neither).
- Full lib suite green.

Note: this necessarily touches all six draw tools — that's where the post-draw hook lives — and the `selectElements` decoupling cascades to the callers above; it's one atomic change. The separate selection-priority routing change will follow in its own PR as agreed.