### PR TITLE
feat(selection): manipulate the selection regardless of the active tool

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/svg/svg.directive.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.directive.spec.ts
@@ -33,6 +33,7 @@ describe('SvgDirective', () => {
       onPointerDown: jest.fn(),
       onPointerMove: jest.fn(),
       onPointerUp: jest.fn(),
+      onPointerCancel: jest.fn(),
       onContextMenu: jest.fn(),
     };
 
@@ -99,6 +100,17 @@ describe('SvgDirective', () => {
     });
     directive.onPointerUp(eventMock);
     expect(svgServiceMock.onPointerUp).toHaveBeenCalled();
+  });
+
+  it('should forward pointercancel / pointerleave to onPointerCancel', () => {
+    const eventMock = withCurrentTarget(new MouseEvent('pointercancel') as PointerEvent, {
+      getBoundingClientRect: () => ({ left: 0, top: 0 }),
+      hasPointerCapture: () => true,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      releasePointerCapture: () => {},
+    });
+    directive.onPointerCancel(eventMock);
+    expect(svgServiceMock.onPointerCancel).toHaveBeenCalled();
   });
 
   it('should forward middle button up to service (no draw end expected)', () => {

--- a/projects/ng-whiteboard/src/lib/core/svg/svg.directive.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.directive.ts
@@ -82,6 +82,15 @@ export class SvgDirective {
     this.svgService.onPointerUp(pointerInfo);
   }
 
+  @HostListener('pointercancel', ['$event'])
+  @HostListener('pointerleave', ['$event'])
+  onPointerCancel(event: PointerEvent): void {
+    if (event.currentTarget && (event.currentTarget as Element).hasPointerCapture(event.pointerId)) {
+      (event.currentTarget as Element).releasePointerCapture(event.pointerId);
+    }
+    this.svgService.onPointerCancel(this.createPointerInfo(event));
+  }
+
   @HostListener('wheel', ['$event'])
   onWheel(event: WheelEvent): void {
     event.preventDefault();

--- a/projects/ng-whiteboard/src/lib/core/svg/svg.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.service.spec.ts
@@ -49,9 +49,10 @@ if (typeof DragEvent === 'undefined') {
 // Mock the target utility
 jest.mock('../utils/dom/target', () => ({
   getTargetElement: jest.fn(),
+  getMouseTarget: jest.fn(),
 }));
 
-import { getTargetElement } from '../utils/dom/target';
+import { getTargetElement, getMouseTarget } from '../utils/dom/target';
 
 describe('SvgService', () => {
   let service: SvgService;
@@ -69,11 +70,20 @@ describe('SvgService', () => {
     handlePointerUp: jest.fn(),
   };
 
+  const selectTool: Tool = {
+    type: ToolType.Select,
+    activate: jest.fn(),
+    deactivate: jest.fn(),
+    handlePointerDown: jest.fn(),
+    handlePointerMove: jest.fn(),
+    handlePointerUp: jest.fn(),
+  };
+
   beforeEach(() => {
     const toolsServiceMock = {
       getActiveToolType: jest.fn().mockReturnValue(ToolType.Pen),
       getActiveToolInstance: jest.fn().mockReturnValue(currentTool),
-      getToolInstance: jest.fn().mockReturnValue(currentTool),
+      getToolInstance: jest.fn((type: ToolType) => (type === ToolType.Select ? selectTool : currentTool)),
       hasTemporaryOverride: jest.fn().mockReturnValue(false),
       pushTemporaryTool: jest.fn(),
       popTemporaryTool: jest.fn(),
@@ -95,6 +105,7 @@ describe('SvgService', () => {
       selectedElements: jest.fn().mockReturnValue([]),
       selectElements: jest.fn(),
       clearSelection: jest.fn(),
+      getBoundingBox: jest.fn().mockReturnValue(null),
     };
 
     const contextMenuServiceMock = {
@@ -211,6 +222,132 @@ describe('SvgService', () => {
     service.onPointerUp(pointerInfo);
 
     expect(eventBusService.emit).not.toHaveBeenCalled();
+  });
+
+  describe('selection gesture capture (non-Select tool active)', () => {
+    let toolsService: jest.Mocked<ToolsService>;
+    const gripTarget = { id: 'selectorGrip_resize_nw', getAttribute: () => null } as unknown as SVGGraphicsElement;
+    const boxTarget = { id: 'selectorBox', getAttribute: () => null } as unknown as SVGGraphicsElement;
+
+    beforeEach(() => {
+      jest.clearAllMocks(); // shared tool mocks accumulate calls across tests; reset before each
+      toolsService = TestBed.inject(ToolsService) as jest.Mocked<ToolsService>;
+      // Something is selected, and the gesture starts on the selection's own UI.
+      apiService.getBoundingBox.mockReturnValue({} as never);
+      (getMouseTarget as jest.Mock).mockReturnValue(gripTarget);
+    });
+
+    it('routes the whole gesture to the Select tool, not the active drawing tool', () => {
+      const down = createMockPointerInfo({ eventType: 'pointerdown' });
+      service.onPointerDown(down);
+      expect(selectTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(currentTool.handlePointerDown).not.toHaveBeenCalled();
+
+      const move = createMockPointerInfo({ eventType: 'pointermove' });
+      service.onPointerMove(move);
+      expect(selectTool.handlePointerMove).toHaveBeenCalledWith(move);
+      expect(currentTool.handlePointerMove).not.toHaveBeenCalled();
+
+      const up = createMockPointerInfo({ eventType: 'pointerup' });
+      service.onPointerUp(up);
+      expect(selectTool.handlePointerUp).toHaveBeenCalledWith(up);
+      expect(currentTool.handlePointerUp).not.toHaveBeenCalled();
+    });
+
+    it('captures on the bounding box as well as the grips', () => {
+      (getMouseTarget as jest.Mock).mockReturnValue(boxTarget);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(selectTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(currentTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('draws normally when nothing is selected', () => {
+      apiService.getBoundingBox.mockReturnValue(null);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(selectTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('draws normally when the gesture starts off the selection UI', () => {
+      (getMouseTarget as jest.Mock).mockReturnValue({
+        id: 'item_abc',
+        getAttribute: () => null,
+      } as unknown as SVGGraphicsElement);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(selectTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('does not hijack the gesture when the Select tool is already active', () => {
+      toolsService.getActiveToolType.mockReturnValue(ToolType.Select);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      // Falls through to the normal active-tool path instead of the capture branch.
+      expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
+    });
+
+    it('never swaps the active tool, so the selection survives the release', () => {
+      service.onPointerDown(createMockPointerInfo({ eventType: 'pointerdown' }));
+      service.onPointerMove(createMockPointerInfo({ eventType: 'pointermove' }));
+      service.onPointerUp(createMockPointerInfo({ eventType: 'pointerup' }));
+
+      // The active tool is never changed, so SelectTool.onDeactivate (which clears the
+      // selection) never runs — the manipulated element stays selected after release.
+      expect(toolsService.pushTemporaryTool).not.toHaveBeenCalled();
+      expect(apiService.clearSelection).not.toHaveBeenCalled();
+    });
+
+    it('releases the capture on pointercancel and stops hijacking moves', () => {
+      service.onPointerDown(createMockPointerInfo({ eventType: 'pointerdown' }));
+      expect(selectTool.handlePointerDown).toHaveBeenCalled();
+
+      const cancel = createMockPointerInfo({ eventType: 'pointercancel' });
+      service.onPointerCancel(cancel);
+      expect(selectTool.handlePointerUp).toHaveBeenCalledWith(cancel);
+
+      // After the gesture is released, a normal move goes back to the drawing tool.
+      const move = createMockPointerInfo({ eventType: 'pointermove' });
+      service.onPointerMove(move);
+      expect(currentTool.handlePointerMove).toHaveBeenCalledWith(move);
+      expect(selectTool.handlePointerMove).not.toHaveBeenCalled();
+    });
+
+    it('pointercancel is a no-op when no selection gesture is in flight', () => {
+      service.onPointerCancel(createMockPointerInfo({ eventType: 'pointercancel' }));
+      expect(selectTool.handlePointerUp).not.toHaveBeenCalled();
+    });
+
+    it('captures on arrow endpoint / curve handles (data-handle)', () => {
+      (getMouseTarget as jest.Mock).mockReturnValue({
+        id: '',
+        getAttribute: (a: string) => (a === 'data-handle' ? 'start' : null),
+      } as unknown as SVGGraphicsElement);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(selectTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(currentTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('draws normally when there is no pointer target', () => {
+      (getMouseTarget as jest.Mock).mockReturnValue(null);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(selectTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('draws normally when the Select tool instance is unavailable', () => {
+      toolsService.getToolInstance.mockImplementation(() => {
+        throw new Error('not registered');
+      });
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(selectTool.handlePointerDown).not.toHaveBeenCalled();
+    });
   });
 
   describe('Context Menu', () => {

--- a/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
@@ -2,14 +2,23 @@ import { Injectable, signal, WritableSignal } from '@angular/core';
 import { ApiService } from '../api/api.service';
 import { ContextMenuService } from '../components/context-menu';
 import { ConfigService } from '../config/config.service';
-import { DROP_EFFECT, KEY, MIME_TYPE, MOUSE_BUTTON, TEMPORARY_TOOL_ID } from '../constants';
+import {
+  DROP_EFFECT,
+  KEY,
+  MIME_TYPE,
+  MOUSE_BUTTON,
+  SELECTOR_BOX,
+  SELECTOR_GRIP_RESIZE,
+  SELECTOR_GRIP_ROTATE,
+  TEMPORARY_TOOL_ID,
+} from '../constants';
 import { EventBusService } from '../event-bus/event-bus.service';
 import { DragDropService } from '../input/drag-drop.service';
 import { KeyboardShortcutService } from '../input/keyboard-shortcut.service';
 import { ToolsService } from '../tools/tools.service';
 import { PointerInfo, WhiteboardEvent } from '../types';
 import { Tool, ToolType } from '../types/tools';
-import { getTargetElement } from '../utils/dom/target';
+import { getMouseTarget, getTargetElement } from '../utils/dom/target';
 import { WheelHandlerService } from '../viewport/wheel-handler.service';
 
 @Injectable({ providedIn: 'root' })
@@ -19,6 +28,9 @@ export class SvgService {
   private readonly pointerUpSig: WritableSignal<PointerInfo | null> = signal<PointerInfo | null>(null);
 
   private isSpaceHeld = false;
+  /** True while a pointer gesture is manipulating the selection (move/resize/rotate) even though
+   *  a non-Select tool is active — see {@link tryBeginSelectionGesture}. */
+  private selectionGesture = false;
 
   constructor(
     private toolsService: ToolsService,
@@ -46,6 +58,12 @@ export class SvgService {
 
     if (!this.canDraw()) return;
 
+    // Selection handles take pointer priority over the active drawing tool: if the gesture
+    // starts on the current selection's own UI (box / resize / rotate / endpoint handles),
+    // drive the Select tool so the element can be moved/resized/rotated WITHOUT switching away
+    // from the drawing tool. Lets a just-drawn element stay fully editable while you keep drawing.
+    if (this.tryBeginSelectionGesture(info)) return;
+
     this.EventBusService.emit(WhiteboardEvent.DrawStart, info);
 
     const currentTool = this.toolsService.getActiveToolInstance();
@@ -68,6 +86,13 @@ export class SvgService {
       return;
     }
 
+    if (this.selectionGesture) {
+      this.EventBusService.emit(WhiteboardEvent.Drawing, info);
+      this.safeGetToolInstance(ToolType.Select)?.handlePointerMove?.(info);
+      this.pointerMoveSig.set(info);
+      return;
+    }
+
     if (!this.canDraw()) return;
 
     this.EventBusService.emit(WhiteboardEvent.Drawing, info);
@@ -83,12 +108,36 @@ export class SvgService {
       return;
     }
 
+    if (this.selectionGesture) {
+      this.endSelectionGesture(info);
+      return;
+    }
+
     if (!this.canDraw()) return;
 
     this.EventBusService.emit(WhiteboardEvent.DrawEnd);
     const currentTool = this.toolsService.getActiveToolInstance();
     currentTool?.handlePointerUp?.(info);
     this.pointerUpSig.set(info);
+  }
+
+  /**
+   * Pointer interaction cut short (pointercancel / pointerleave): if a selection gesture is in
+   * flight, finalize it cleanly so the flag never sticks. `SelectTool.handlePointerUp` commits any
+   * open batch and resets its own state, so this leaves nothing dangling.
+   */
+  onPointerCancel(info: PointerInfo): void {
+    if (this.selectionGesture) {
+      this.endSelectionGesture(info);
+    }
+  }
+
+  /** Hand the up/cancel to the Select tool and clear the capture flag. */
+  private endSelectionGesture(info: PointerInfo): void {
+    this.EventBusService.emit(WhiteboardEvent.DrawEnd);
+    this.safeGetToolInstance(ToolType.Select)?.handlePointerUp?.(info);
+    this.pointerUpSig.set(info);
+    this.selectionGesture = false;
   }
 
   onKeyDown(event: KeyboardEvent) {
@@ -210,11 +259,50 @@ export class SvgService {
   }
 
   private safeGetHandTool(): Tool | null {
+    return this.safeGetToolInstance(ToolType.Hand);
+  }
+
+  private safeGetToolInstance(type: ToolType): Tool | null {
     try {
-      return this.toolsService.getToolInstance(ToolType.Hand);
+      return this.toolsService.getToolInstance(type);
     } catch {
       return null;
     }
+  }
+
+  /**
+   * True when the pointer landed on the current selection's own UI — its bounding box, the
+   * resize/rotate grips, or an arrow endpoint/curve handle. These imply "manipulate the
+   * selection", as opposed to drawing on empty canvas.
+   */
+  private isSelectionHandleTarget(target: SVGGraphicsElement | null): boolean {
+    if (!target) return false;
+    const id = target.id ?? '';
+    if (id.includes(SELECTOR_GRIP_RESIZE) || id.includes(SELECTOR_GRIP_ROTATE) || id.includes(SELECTOR_BOX)) {
+      return true;
+    }
+    const handle = typeof target.getAttribute === 'function' ? target.getAttribute('data-handle') : null;
+    return handle === 'start' || handle === 'end' || handle === 'curve';
+  }
+
+  /**
+   * If a non-Select tool is active, something is selected, and the gesture starts on that
+   * selection's UI, route the whole gesture (down → move → up) to the Select tool instead of
+   * the active drawing tool. Returns true when the gesture was captured.
+   */
+  private tryBeginSelectionGesture(info: PointerInfo): boolean {
+    if (this.toolsService.getActiveToolType() === ToolType.Select) return false;
+    if (!this.apiService.getBoundingBox()) return false;
+    if (!this.isSelectionHandleTarget(getMouseTarget(info))) return false;
+
+    const selectTool = this.safeGetToolInstance(ToolType.Select);
+    if (!selectTool) return false;
+
+    this.selectionGesture = true;
+    this.EventBusService.emit(WhiteboardEvent.DrawStart, info);
+    selectTool.handlePointerDown?.(info);
+    this.pointerDownSig.set(info);
+    return true;
   }
 
   /**


### PR DESCRIPTION
Follow-up to #394 — the selection-priority change we discussed there.

## What
Selection handles take pointer priority over the active drawing tool. When a gesture starts on the current selection's own UI — bounding box, resize/rotate grips, or arrow endpoint/curve handles — the dispatcher routes the whole gesture (down → move → up) to the Select tool, even while a draw tool is active. So a just-drawn element can be moved/resized/rotated without switching away from the drawing tool.

## Approach
As agreed, this avoids `pushTemporaryTool(Select)` (popping it deactivates Select → `onDeactivate()` clears the selection on release). Instead it's a self-contained capture in `SvgService`: the gesture is driven straight through the existing `SelectTool` handlers via `getToolInstance(Select)`, without making it the active tool. The active tool never changes, so `onDeactivate()` never runs and the selection survives the release; normal tool-switching is untouched. (Mirrors how the hand tool is already driven directly in the dispatcher.)

## Scope
- Captures only when something is selected AND the gesture begins on the selection UI.
- Drawing on empty canvas (or off the selection UI) is unaffected.
- Released on pointerup and on pointercancel / pointerleave, so the capture never sticks if a gesture is cut short (`SelectTool.handlePointerUp` commits any open batch and resets state).

## Tests
Capture vs non-capture paths, selection surviving release (no tool swap), release on cancel, and the directive forwarding pointercancel/leave. Full lib suite green.