### PR TITLE
fix(selection): move selected lines/arrows while a drawing tool is active

### DIFF
--- a/projects/ng-whiteboard/src/lib/core/svg/svg.service.spec.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.service.spec.ts
@@ -232,9 +232,12 @@ describe('SvgService', () => {
     beforeEach(() => {
       jest.clearAllMocks(); // shared tool mocks accumulate calls across tests; reset before each
       toolsService = TestBed.inject(ToolsService) as jest.Mocked<ToolsService>;
-      // Something is selected, and the gesture starts on the selection's own UI.
+      // Something is selected, and the gesture starts on the selection's own UI. A non-empty
+      // selection is the gate (NOT the bounding box — line/arrow selections have none).
+      apiService.selectedElements.mockReturnValue([{ id: 'sel-1' } as WhiteboardElement]);
       apiService.getBoundingBox.mockReturnValue({} as never);
       (getMouseTarget as jest.Mock).mockReturnValue(gripTarget);
+      (getTargetElement as jest.Mock).mockReturnValue(null); // body-target off by default
     });
 
     it('routes the whole gesture to the Select tool, not the active drawing tool', () => {
@@ -263,7 +266,7 @@ describe('SvgService', () => {
     });
 
     it('draws normally when nothing is selected', () => {
-      apiService.getBoundingBox.mockReturnValue(null);
+      apiService.selectedElements.mockReturnValue([]);
       const down = createMockPointerInfo();
       service.onPointerDown(down);
       expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
@@ -329,6 +332,52 @@ describe('SvgService', () => {
       service.onPointerDown(down);
       expect(selectTool.handlePointerDown).toHaveBeenCalledWith(down);
       expect(currentTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('captures on a line/arrow handle even though the selection has no bounding box', () => {
+      // Regression: line/arrow selections use endpoint/curve handles and have NO bounding box.
+      // The capture must not gate on getBoundingBox() or it would never fire for them — the bug
+      // where a just-drawn arrow looked selected but a click started a new arrow instead.
+      apiService.getBoundingBox.mockReturnValue(null);
+      (getMouseTarget as jest.Mock).mockReturnValue({
+        id: '',
+        getAttribute: (a: string) => (a === 'data-handle' ? 'end' : null),
+      } as unknown as SVGGraphicsElement);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(selectTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(currentTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('captures when the gesture starts on the body of an already-selected element', () => {
+      // A selected line/arrow has no box to grab — dragging its body should move it (like the
+      // Select tool), so the capture also fires when the pointer's element is in the selection.
+      apiService.getBoundingBox.mockReturnValue(null);
+      const selected = { id: 'sel-1' } as WhiteboardElement;
+      apiService.selectedElements.mockReturnValue([selected]);
+      (getMouseTarget as jest.Mock).mockReturnValue({
+        id: 'item_sel-1',
+        getAttribute: () => null,
+      } as unknown as SVGGraphicsElement);
+      (getTargetElement as jest.Mock).mockReturnValue(selected);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(selectTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(currentTool.handlePointerDown).not.toHaveBeenCalled();
+    });
+
+    it('draws normally on the body of an element that is not selected', () => {
+      const selected = { id: 'sel-1' } as WhiteboardElement;
+      apiService.selectedElements.mockReturnValue([selected]);
+      (getMouseTarget as jest.Mock).mockReturnValue({
+        id: 'item_other',
+        getAttribute: () => null,
+      } as unknown as SVGGraphicsElement);
+      (getTargetElement as jest.Mock).mockReturnValue({ id: 'other' } as WhiteboardElement);
+      const down = createMockPointerInfo();
+      service.onPointerDown(down);
+      expect(currentTool.handlePointerDown).toHaveBeenCalledWith(down);
+      expect(selectTool.handlePointerDown).not.toHaveBeenCalled();
     });
 
     it('draws normally when there is no pointer target', () => {

--- a/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
+++ b/projects/ng-whiteboard/src/lib/core/svg/svg.service.ts
@@ -292,8 +292,14 @@ export class SvgService {
    */
   private tryBeginSelectionGesture(info: PointerInfo): boolean {
     if (this.toolsService.getActiveToolType() === ToolType.Select) return false;
-    if (!this.apiService.getBoundingBox()) return false;
-    if (!this.isSelectionHandleTarget(getMouseTarget(info))) return false;
+    // Need an existing selection to manipulate. We can't gate on getBoundingBox() here: line and
+    // arrow selections have NO bounding box (they use their own endpoint/curve handles), so that
+    // guard would wrongly exclude them and the gesture would fall through to the drawing tool.
+    if (this.apiService.selectedElements().length === 0) return false;
+    // Capture when the gesture starts on the selection's own UI (box / resize / rotate / endpoint /
+    // curve handles) OR on the body of an already-selected element — the latter lets a selected
+    // line/arrow be moved by its body, matching the Select tool (they have no box to grab).
+    if (!this.isSelectionHandleTarget(getMouseTarget(info)) && !this.isSelectedElementTarget(info)) return false;
 
     const selectTool = this.safeGetToolInstance(ToolType.Select);
     if (!selectTool) return false;
@@ -303,6 +309,17 @@ export class SvgService {
     selectTool.handlePointerDown?.(info);
     this.pointerDownSig.set(info);
     return true;
+  }
+
+  /**
+   * True when the pointer landed on the body of an element that is currently selected. Lets a
+   * selected line/arrow — which has no bounding box, only endpoint/curve handles — be moved by
+   * dragging its body while a drawing tool stays active, matching the Select tool's behaviour.
+   */
+  private isSelectedElementTarget(info: PointerInfo): boolean {
+    const targetElement = this.getTargetElementFromPointer(info);
+    if (!targetElement) return false;
+    return this.apiService.selectedElements().some((el) => el.id === targetElement.id);
   }
 
   /**


### PR DESCRIPTION
Follow-up to #396.

## Problem

#396 lets you manipulate the current selection while a non-Select tool is active, by routing gestures that start on the selection UI to the Select tool. The capture guard requires a bounding box (`getBoundingBox()`), but **line and arrow selections have no bounding box** — they render their own endpoint/curve handles. So for a selected line/arrow the guard is always null and the gesture falls through to the drawing tool: a just-drawn arrow looks selected, but clicking its handles or body starts a **new** arrow instead of moving it.

## Fix

- Gate `tryBeginSelectionGesture` on there being a selection (`selectedElements().length`) rather than on a bounding box.
- Also capture when the gesture starts on the **body of an already-selected element**, so a selected line/arrow can be dragged by its body (matching the Select tool). Box-backed shapes stay grabbable via their bounding box as before.

## Tests

- Updated the selection-gesture specs to gate on selection state.
- Added coverage for the no-bounding-box handle case (the regression), the selected-body case, and draw-through on a non-selected element's body.

Full library suite green; `build:lib` passes.
